### PR TITLE
feat: implement POST /api/v1/signup endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,14 @@ All commands should be run inside the Docker container. From the host OS, prefix
 
 ### Validation
 - Use `@hono/standard-validator` with Zod schemas
-- Define validators before route handlers using `sValidator`
+- Define validators as separate variables (e.g., `const jsonValidator = sValidator(...)` ) before the route handler
 - Return appropriate HTTP status codes in validation error handlers (e.g., 400 for bad requests)
 
+### Constants ( `@/consts` )
+- Define status message constants (e.g., `BAD_REQUEST` , `CONFLICT` , `OK` )
+- Define duration constants in milliseconds (e.g., `SIGNUP_SESSION_EXPIRATION_MS` )
+
 ### Error handling
-- Define status message constants in `@/consts` (e.g., `BAD_REQUEST` , `CONFLICT`, `OK` )
 - Use `c.text(MESSAGE, statusCode)` for responses
 - Apply `injectExternalErrors` middleware to handle external service errors
 - Common status codes:
@@ -94,6 +97,12 @@ All commands should be run inside the Docker container. From the host OS, prefix
 ### Date Utilities ( `@/utils/date` )
 
 - `offsetMilliSeconds(date: Date, ms: number): Date`
+
+### Crypto Utilities ( `@/utils/crypto/server` )
+
+- `generateUuidv7(): string` - Generates a time-ordered UUIDv7 for database primary keys
+- `generateSecureToken(bytes?: number): string` - Generates a URL-safe base64 encoded random token
+- `hashToken(token: string): string` - Hashes a token using SHA-256 for secure storage
 
 ## Testing instructions
 1. add the function

--- a/app/consts.ts
+++ b/app/consts.ts
@@ -1,0 +1,6 @@
+export const OK = "OK";
+export const BAD_REQUEST = "Bad Request";
+export const CONFLICT = "Conflict";
+export const INTERNAL_SERVER_ERROR = "Internal Server Error";
+
+export const SIGNUP_SESSION_EXPIRATION_MS = 24 * 60 * 60 * 1000; // 24 hours

--- a/app/db/client.ts
+++ b/app/db/client.ts
@@ -1,0 +1,22 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { drizzle } from "drizzle-orm/d1";
+import * as schemas from "@/db/schemas";
+
+export type DBClient = DrizzleD1Database<typeof schemas>;
+
+const clientCache = new WeakMap<D1Database, DBClient>();
+
+export function getDBClient(d1: D1Database): DBClient {
+	const cachedClient = clientCache.get(d1);
+
+	if (cachedClient) {
+		return cachedClient;
+	}
+
+	const client = drizzle(d1, { schema: schemas });
+
+	clientCache.set(d1, client);
+
+	return client;
+}

--- a/app/db/schemas.ts
+++ b/app/db/schemas.ts
@@ -1,0 +1,36 @@
+import { sql } from "drizzle-orm";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/** Helper function to define a timestamp column */
+const timestamp = (name: string) => integer(name, { mode: "timestamp" });
+
+/** Helper function to get the current Unix epoch time */
+const now = () => sql`(unixepoch())`;
+
+/** `users` table schema definition */
+export const usersTable = sqliteTable("users", {
+	/** UUIDv7 */
+	id: text("id").primaryKey(),
+	/** User's email address */
+	email: text("email").notNull().unique(),
+	/** Salt used for password hashing */
+	salt: text("salt"),
+	/** Hashed password */
+	passwordHash: text("password_hash"),
+	/** Google account ID (unique identifier from Google OAuth) */
+	googleId: text("google_id").unique(),
+	/** Timestamp of user creation */
+	createdAt: timestamp("created_at").notNull().default(now()),
+});
+
+/** `signup_sessions` table schema definition */
+export const signupSessionsTable = sqliteTable("signup_sessions", {
+	/** UUIDv7 */
+	id: text("id").primaryKey(),
+	/** Email address for signup */
+	email: text("email").notNull(),
+	/** SHA-256 hash of the verification token */
+	tokenHash: text("token_hash").notNull().unique(),
+	/** Expiration timestamp */
+	expiresAt: timestamp("expires_at").notNull(),
+});

--- a/app/email/client.ts
+++ b/app/email/client.ts
@@ -1,0 +1,17 @@
+import { Resend } from "resend";
+
+const clientCache = new Map<string, Resend>();
+
+export function getEmailClient(apiKey: string): Resend {
+	const cachedClient = clientCache.get(apiKey);
+
+	if (cachedClient) {
+		return cachedClient;
+	}
+
+	const client = new Resend(apiKey);
+
+	clientCache.set(apiKey, client);
+
+	return client;
+}

--- a/app/email/templates/signup-verification.tsx
+++ b/app/email/templates/signup-verification.tsx
@@ -1,0 +1,14 @@
+import type { FC } from "hono/jsx";
+
+interface Props {
+	verifyUrl: string;
+}
+
+export const SignupVerificationEmail: FC<Props> = ({ verifyUrl }) => (
+	<>
+		<p>以下のリンクをクリックして、メールアドレスを確認してください：</p>
+		<p>
+			<a href={verifyUrl}>{verifyUrl}</a>
+		</p>
+	</>
+);

--- a/app/routes/api/v1/signup/index.tsx
+++ b/app/routes/api/v1/signup/index.tsx
@@ -1,0 +1,100 @@
+import { sValidator } from "@hono/standard-validator";
+import { eq } from "drizzle-orm";
+import { renderToString } from "hono/jsx/dom/server";
+import { z } from "zod/v4";
+import {
+	BAD_REQUEST,
+	CONFLICT,
+	INTERNAL_SERVER_ERROR,
+	OK,
+	SIGNUP_SESSION_EXPIRATION_MS,
+} from "@/consts";
+import { getDBClient } from "@/db/client";
+import { signupSessionsTable, usersTable } from "@/db/schemas";
+import { getEmailClient } from "@/email/client";
+import { SignupVerificationEmail } from "@/email/templates/signup-verification";
+import {
+	generateSecureToken,
+	generateUuidv7,
+	hashToken,
+} from "@/utils/crypto/server";
+import { offsetMilliSeconds } from "@/utils/date";
+import { createHonoApp } from "@/utils/factory/hono";
+
+const jsonValidator = sValidator(
+	"json",
+	z.object({
+		email: z.email(),
+	}),
+	(result, c) => {
+		if (!result.success) {
+			return c.text(BAD_REQUEST, 400);
+		}
+	},
+);
+
+export const route = createHonoApp().post("/", jsonValidator, async (c) => {
+	const { email } = c.req.valid("json");
+
+	const db = getDBClient(c.env.DB);
+
+	const existingUser = await db
+		.select()
+		.from(usersTable)
+		.where(eq(usersTable.email, email))
+		.get();
+
+	if (existingUser) {
+		return c.text(CONFLICT, 409);
+	}
+
+	const existingSession = await db
+		.select()
+		.from(signupSessionsTable)
+		.where(eq(signupSessionsTable.email, email))
+		.get();
+
+	if (existingSession) {
+		await db
+			.delete(signupSessionsTable)
+			.where(eq(signupSessionsTable.email, email));
+	}
+
+	const id = generateUuidv7();
+	const token = generateSecureToken();
+	const tokenHash = hashToken(token);
+
+	const now = new Date();
+	const expiresAt = offsetMilliSeconds(now, SIGNUP_SESSION_EXPIRATION_MS);
+
+	await db.insert(signupSessionsTable).values({
+		id,
+		email,
+		tokenHash,
+		expiresAt,
+	});
+
+	const resend = getEmailClient(c.env.RESEND_API_KEY);
+
+	const url = new URL(c.req.url);
+	const verifyUrl = `${url.origin}/signup/verify?token=${token}`;
+
+	const html = renderToString(
+		<SignupVerificationEmail verifyUrl={verifyUrl} />,
+	);
+
+	const { error } = await resend.emails.send({
+		from: c.env.RESEND_EMAIL_FROM,
+		to: email,
+		subject: "メールアドレスの確認",
+		html,
+	});
+
+	if (error) {
+		return c.text(INTERNAL_SERVER_ERROR, 500);
+	}
+
+	return c.text(OK, 200);
+});
+
+export default route;

--- a/app/utils/crypto/server.spec.ts
+++ b/app/utils/crypto/server.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+import { setTimeout } from "node:timers/promises";
+import { generateSecureToken, generateUuidv7, hashToken } from "./server";
+
+describe("generateUuidv7", () => {
+	it("should generate a valid UUIDv7 format", () => {
+		const uuid = generateUuidv7();
+		const uuidRegex =
+			/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+		expect(uuid).toMatch(uuidRegex);
+	});
+
+	it("should have version 7 identifier", () => {
+		const uuid = generateUuidv7();
+		const version = uuid[14];
+
+		expect(version).toBe("7");
+	});
+
+	it("should have correct variant bits", () => {
+		const uuid = generateUuidv7();
+		const variant = uuid[19];
+
+		if (variant === undefined) {
+			throw new Error("UUID variant character is undefined");
+		}
+
+		expect(["8", "9", "a", "b"]).toContain(variant.toLowerCase());
+	});
+
+	it("should generate unique UUIDs", () => {
+		const uuid1 = generateUuidv7();
+		const uuid2 = generateUuidv7();
+
+		expect(uuid1).not.toBe(uuid2);
+	});
+
+	it("should generate time-ordered UUIDs", async () => {
+		const uuid1 = generateUuidv7();
+
+		await setTimeout(1);
+
+		const uuid2 = generateUuidv7();
+
+		expect(uuid1 < uuid2).toBe(true);
+	});
+});
+
+describe("generateSecureToken", () => {
+	it("should generate a token with default length (32 bytes)", () => {
+		const token = generateSecureToken();
+		const decoded = Buffer.from(token, "base64url");
+
+		expect(decoded.length).toBe(32);
+	});
+
+	it("should generate a token with custom byte length", () => {
+		const bytes = 16;
+		const token = generateSecureToken(bytes);
+		const decoded = Buffer.from(token, "base64url");
+
+		expect(decoded.length).toBe(bytes);
+	});
+
+	it("should generate URL-safe tokens (base64url)", () => {
+		const token = generateSecureToken();
+		const urlUnsafeChars = /[+/=]/;
+
+		expect(token).not.toMatch(urlUnsafeChars);
+	});
+
+	it("should generate unique tokens", () => {
+		const token1 = generateSecureToken();
+		const token2 = generateSecureToken();
+
+		expect(token1).not.toBe(token2);
+	});
+
+	it("should only contain valid base64url characters", () => {
+		const token = generateSecureToken();
+		const base64urlRegex = /^[A-Za-z0-9_-]+$/;
+
+		expect(token).toMatch(base64urlRegex);
+	});
+
+	it("should generate tokens of different lengths", () => {
+		const token8 = generateSecureToken(8);
+		const token16 = generateSecureToken(16);
+		const token32 = generateSecureToken(32);
+
+		expect(token8.length).toBeLessThan(token16.length);
+		expect(token16.length).toBeLessThan(token32.length);
+	});
+});
+
+describe("hashToken", () => {
+	it("should produce consistent hashes for the same input", () => {
+		const token = "test-token-12345";
+		const hash1 = hashToken(token);
+		const hash2 = hashToken(token);
+
+		expect(hash1).toBe(hash2);
+	});
+
+	it("should produce different hashes for different inputs", () => {
+		const token1 = "test-token-1";
+		const token2 = "test-token-2";
+		const hash1 = hashToken(token1);
+		const hash2 = hashToken(token2);
+
+		expect(hash1).not.toBe(hash2);
+	});
+
+	it("should produce SHA-256 hash (64 hex characters)", () => {
+		const token = "test-token-12345";
+		const hash = hashToken(token);
+
+		expect(hash.length).toBe(64);
+	});
+
+	it("should only contain hexadecimal characters", () => {
+		const token = "test-token-12345";
+		const hash = hashToken(token);
+
+		expect(hash).toMatch(/^[0-9a-f]+$/);
+	});
+
+	it("should handle empty string", () => {
+		const hash = hashToken("");
+
+		expect(hash.length).toBe(64);
+	});
+});

--- a/app/utils/crypto/server.ts
+++ b/app/utils/crypto/server.ts
@@ -1,0 +1,81 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Generates a UUIDv7 (time-ordered UUID).
+ *
+ * UUIDv7 embeds a timestamp in the first 48 bits, making it suitable for
+ * time-based sorting and indexing. The remaining bits are filled with
+ * cryptographically secure random data.
+ *
+ * @returns A UUIDv7 string in the format `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+ *
+ * @example
+ * const userId = generateUuidv7();
+ * // => "018d3f5e-5c3a-7000-8000-123456789abc"
+ * // Can be sorted chronologically
+ */
+export function generateUuidv7(): string {
+	const timestamp = Date.now();
+
+	const buffer = Buffer.alloc(16);
+	buffer.writeUIntBE(timestamp, 0, 6);
+
+	const randomData = randomBytes(10);
+	randomData.copy(buffer, 6);
+
+	const byte6 = buffer[6];
+
+	if (byte6 === undefined) {
+		throw new Error("Failed to generate UUIDv7");
+	}
+
+	buffer[6] = (byte6 & 0x0f) | 0x70;
+
+	const byte8 = buffer[8];
+
+	if (byte8 === undefined) {
+		throw new Error("Failed to generate UUIDv7");
+	}
+
+	buffer[8] = (byte8 & 0x3f) | 0x80;
+
+	const hex = buffer.toString("hex");
+
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/**
+ * Generates a cryptographically secure random token.
+ *
+ * @param bytes - Number of random bytes to generate (default: 32)
+ * @returns URL-safe base64 encoded string
+ *
+ * @example
+ * const signupToken = generateSecureToken(); // 256-bit token
+ * const shortToken = generateSecureToken(16); // 128-bit token
+ */
+export function generateSecureToken(bytes = 32): string {
+	return randomBytes(bytes).toString("base64url");
+}
+
+/**
+ * Hashes a token using SHA-256.
+ *
+ * This is used to securely store tokens in the database. Never store tokens
+ * in plain text - always hash them first and compare hashes.
+ *
+ * @param token - The token to hash
+ * @returns Hexadecimal string representation of the SHA-256 hash
+ *
+ * @example
+ * const token = generateSecureToken();
+ * const tokenHash = hashToken(token);
+ * // Store tokenHash in database, send token to user
+ *
+ * // Later, to verify:
+ * const receivedTokenHash = hashToken(receivedToken);
+ * // Compare receivedTokenHash with stored hash
+ */
+export function hashToken(token: string): string {
+	return createHash("sha256").update(token).digest("hex");
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,23 @@
+# API Documentation
+
+## Table of Contents
+- [Endpoints](#Endpoints)
+    - [`POST /api/v1/signup`](#POST-apiv1signup) : Create a new user account and send a verification email.
+
+## Endpoints
+
+### `POST /api/v1/signup`
+
+```ts
+type RequestJSON = {
+  email: string;
+}
+
+type ResponseText = "OK"
+```
+
+1. Returns `400 Bad Request` if the request body is not valid JSON
+2. Returns `400 Bad Request` if the email address is invalid
+3. Returns `409 Conflict` if the email address is already registered
+4. Sends a verification email with an invitation URL ( `/signup/verify?token={signup_session_token}` )
+5. Returns `200 OK`


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/signup` endpoint with email validation using sValidator + Zod
- Create `signupSessionsTable` schema for email verification sessions
- Add crypto utilities (UUIDv7, secure token, SHA-256 hash)
- Add email client wrapper and JSX email templates
- Add API documentation

## Test plan
- [x] All unit tests pass (`bun run test:unit`)
- [x] All E2E tests pass (`bun run test:e2e`)
- [x] TypeScript type check passes (`bun run tsc`)
- [x] Biome linter passes (`bun run biome`)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)