### PR TITLE
Add POST /api/v1/signup/verify endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,13 +125,19 @@ For all GitHub operations (creating issues, pull requests, searching code, etc.)
 
 ### Working on an issue
 1. Create issue using `gh issue create`
-2. Create and checkout a new branch named `feature/#n` from the `main` branch (where `#n` is the issue number)
+2. Create and checkout a new branch named `feature/#n` from the `main` or `release/X.Y.Z` branch (where `#n` is the issue number)
 3. Implement the feature
 4. Run all checks: `bun run biome && bun run tsc && bun run test:unit && bun run test:e2e`
 5. Commit changes with `Closes #n` in the commit message to auto-close the issue on merge
 6. Push the branch: `git push -u origin feature/#n`
-7. Create a pull request using `gh pr create --base main --head feature/#n`
+7. Create a pull request using `gh pr create --base <main or release/X.Y.Z> --head feature/#n`
 8. After PR is merged, delete the remote branch
+
+### Release workflow
+1. Create a `release/X.Y.Z` branch from `main`
+2. Merge feature branches into `release/X.Y.Z`
+3. When ready, create a PR to merge `release/X.Y.Z` into `main`
+4. After PR is merged into `main`, create a tag and release: `git tag vX.Y.Z && git push origin vX.Y.Z && gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."`
 
 ### Commit messages
 - Use conventional commit format with lowercase prefixes (e.g., "feat:", "fix:", "chore:")

--- a/app/consts.ts
+++ b/app/consts.ts
@@ -4,3 +4,8 @@ export const CONFLICT = "Conflict";
 export const INTERNAL_SERVER_ERROR = "Internal Server Error";
 
 export const SIGNUP_SESSION_EXPIRATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export const ACCESS_TOKEN_COOKIE_NAME = "access_token";
+export const ACCESS_TOKEN_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export const PASSWORD_MIN_LENGTH = 8;

--- a/app/routes/api/v1/signup/verify.ts
+++ b/app/routes/api/v1/signup/verify.ts
@@ -1,0 +1,93 @@
+import { sValidator } from "@hono/standard-validator";
+import { eq } from "drizzle-orm";
+import { z } from "zod/v4";
+import { BAD_REQUEST, CONFLICT, OK } from "@/consts";
+import { getDBClient } from "@/db/client";
+import { signupSessionsTable, usersTable } from "@/db/schemas";
+import { generateAccessToken, setAccessTokenCookie } from "@/utils/cookie";
+import {
+	generateSalt,
+	generateUuidv7,
+	hashPassword,
+	hashToken,
+} from "@/utils/crypto/server";
+import { createHonoApp } from "@/utils/factory/hono";
+import { validatePassword } from "@/utils/validation";
+
+const jsonValidator = sValidator(
+	"json",
+	z.object({
+		signupSessionToken: z.string().min(1),
+		password: z.string().min(1),
+	}),
+	(result, c) => {
+		if (!result.success) {
+			return c.text(BAD_REQUEST, 400);
+		}
+	},
+);
+
+export const route = createHonoApp().post("/", jsonValidator, async (c) => {
+	const { signupSessionToken, password } = c.req.valid("json");
+
+	const db = getDBClient(c.env.DB);
+
+	const tokenHash = hashToken(signupSessionToken);
+	const session = await db
+		.select()
+		.from(signupSessionsTable)
+		.where(eq(signupSessionsTable.tokenHash, tokenHash))
+		.get();
+
+	if (!session) {
+		return c.text(BAD_REQUEST, 400);
+	}
+
+	const now = new Date();
+	if (session.expiresAt < now) {
+		await db
+			.delete(signupSessionsTable)
+			.where(eq(signupSessionsTable.id, session.id));
+		return c.text(BAD_REQUEST, 400);
+	}
+
+	if (!validatePassword(password, session.email).isValid) {
+		return c.text(BAD_REQUEST, 400);
+	}
+
+	const existingUser = await db
+		.select()
+		.from(usersTable)
+		.where(eq(usersTable.email, session.email))
+		.get();
+
+	if (existingUser) {
+		return c.text(CONFLICT, 409);
+	}
+
+	const userId = generateUuidv7();
+	const salt = generateSalt();
+	const passwordHash = hashPassword(password, salt);
+
+	await db.insert(usersTable).values({
+		id: userId,
+		email: session.email,
+		salt,
+		passwordHash,
+	});
+
+	await db
+		.delete(signupSessionsTable)
+		.where(eq(signupSessionsTable.id, session.id));
+
+	const token = await generateAccessToken(
+		userId,
+		session.email,
+		c.env.JWT_SECRET,
+	);
+	setAccessTokenCookie(c, token);
+
+	return c.text(OK, 200);
+});
+
+export default route;

--- a/app/utils/cookie/index.ts
+++ b/app/utils/cookie/index.ts
@@ -1,0 +1,52 @@
+import type { Context } from "hono";
+import { setCookie } from "hono/cookie";
+import { sign } from "hono/jwt";
+import type { JWTPayload } from "hono/utils/jwt/types";
+import { ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN_EXPIRATION_MS } from "@/consts";
+
+export type AccessTokenPayload = JWTPayload & {
+	sub: string;
+	email: string;
+};
+
+/**
+ * Generates a JWT access token for authentication.
+ *
+ * @param userId - The user's ID (UUIDv7)
+ * @param email - The user's email address
+ * @param secret - The JWT secret key
+ * @returns Promise resolving to the signed JWT access token
+ */
+export async function generateAccessToken(
+	userId: string,
+	email: string,
+	secret: string,
+): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	const exp = now + Math.floor(ACCESS_TOKEN_EXPIRATION_MS / 1000);
+
+	const payload: AccessTokenPayload = {
+		sub: userId,
+		email,
+		exp,
+		iat: now,
+	};
+
+	return await sign(payload, secret);
+}
+
+/**
+ * Sets the access token cookie with the JWT.
+ *
+ * @param c - The Hono context
+ * @param token - The JWT access token to set
+ */
+export function setAccessTokenCookie(c: Context, token: string): void {
+	setCookie(c, ACCESS_TOKEN_COOKIE_NAME, token, {
+		httpOnly: true,
+		secure: true,
+		sameSite: "Strict",
+		path: "/",
+		maxAge: Math.floor(ACCESS_TOKEN_EXPIRATION_MS / 1000),
+	});
+}

--- a/app/utils/crypto/server.ts
+++ b/app/utils/crypto/server.ts
@@ -79,3 +79,33 @@ export function generateSecureToken(bytes = 32): string {
 export function hashToken(token: string): string {
 	return createHash("sha256").update(token).digest("hex");
 }
+
+/**
+ * Generates a cryptographically secure random salt for password hashing.
+ *
+ * @param bytes - Number of random bytes to generate (default: 16)
+ * @returns Hexadecimal string representation of the salt
+ *
+ * @example
+ * const salt = generateSalt();
+ * // => "a1b2c3d4e5f6..."
+ */
+export function generateSalt(bytes = 16): string {
+	return randomBytes(bytes).toString("hex");
+}
+
+/**
+ * Hashes a password with a salt using SHA-256.
+ *
+ * @param password - The password to hash
+ * @param salt - The salt to use for hashing
+ * @returns Hexadecimal string representation of the hashed password
+ *
+ * @example
+ * const salt = generateSalt();
+ * const hash = hashPassword("myPassword123", salt);
+ * // Store both salt and hash in database
+ */
+export function hashPassword(password: string, salt: string): string {
+	return createHash("sha256").update(`${salt}${password}`).digest("hex");
+}

--- a/app/utils/validation/index.ts
+++ b/app/utils/validation/index.ts
@@ -1,0 +1,81 @@
+import { PASSWORD_MIN_LENGTH } from "@/consts";
+
+export type PasswordValidationResult = {
+	isMinLength: boolean;
+	hasLowercase: boolean;
+	hasUppercase: boolean;
+	hasNumber: boolean;
+	hasSymbol: boolean;
+	hasThreeTypes: boolean;
+	isNotSimilarToEmail: boolean;
+	isValid: boolean;
+};
+
+export function checkPasswordMinLength(password: string): boolean {
+	return password.length >= PASSWORD_MIN_LENGTH;
+}
+
+export function checkPasswordHasLowercase(password: string): boolean {
+	return /[a-z]/.test(password);
+}
+
+export function checkPasswordHasUppercase(password: string): boolean {
+	return /[A-Z]/.test(password);
+}
+
+export function checkPasswordHasNumber(password: string): boolean {
+	return /[0-9]/.test(password);
+}
+
+export function checkPasswordHasSymbol(password: string): boolean {
+	return /[^a-zA-Z0-9]/.test(password);
+}
+
+export function checkPasswordHasThreeTypes(password: string): boolean {
+	let typeCount = 0;
+	if (checkPasswordHasLowercase(password)) typeCount++;
+	if (checkPasswordHasUppercase(password)) typeCount++;
+	if (checkPasswordHasNumber(password)) typeCount++;
+	if (checkPasswordHasSymbol(password)) typeCount++;
+	return typeCount >= 3;
+}
+
+export function checkPasswordNotSimilarToEmail(
+	password: string,
+	email: string,
+): boolean {
+	const emailLocalPart = email.split("@")[0]?.toLowerCase() ?? "";
+	if (
+		emailLocalPart.length >= 3 &&
+		password.toLowerCase().includes(emailLocalPart)
+	) {
+		return false;
+	}
+	return true;
+}
+
+export function validatePassword(
+	password: string,
+	email: string,
+): PasswordValidationResult {
+	const isMinLength = checkPasswordMinLength(password);
+	const hasLowercase = checkPasswordHasLowercase(password);
+	const hasUppercase = checkPasswordHasUppercase(password);
+	const hasNumber = checkPasswordHasNumber(password);
+	const hasSymbol = checkPasswordHasSymbol(password);
+	const hasThreeTypes = checkPasswordHasThreeTypes(password);
+	const isNotSimilarToEmail = checkPasswordNotSimilarToEmail(password, email);
+
+	const isValid = isMinLength && hasThreeTypes && isNotSimilarToEmail;
+
+	return {
+		isMinLength,
+		hasLowercase,
+		hasUppercase,
+		hasNumber,
+		hasSymbol,
+		hasThreeTypes,
+		isNotSimilarToEmail,
+		isValid,
+	};
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 - [Endpoints](#Endpoints)
     - [`POST /api/v1/signup`](#POST-apiv1signup) : Create a new user account and send a verification email.
+    - [`POST /api/v1/signup/verify`](#POST-apiv1signupverify) : Verify signup session and create user account.
 
 ## Endpoints
 
@@ -10,7 +11,7 @@
 
 ```ts
 type RequestJSON = {
-  email: string;
+    email: string;
 }
 
 type ResponseText = "OK"
@@ -21,3 +22,28 @@ type ResponseText = "OK"
 3. Returns `409 Conflict` if the email address is already registered
 4. Sends a verification email with an invitation URL ( `/signup/verify?token={signup_session_token}` )
 5. Returns `200 OK`
+
+### `POST /api/v1/signup/verify`
+
+```ts
+type RequestJSON = {
+    signupSessionToken: string;
+    password: string;
+}
+
+type ResponseText = "OK" | "Bad Request" | "Conflict"
+```
+
+#### Password Requirements
+- At least 8 characters
+- Contains 3 or more types from: lowercase letters, uppercase letters, numbers, symbols
+- Not similar to the email address
+
+#### Flow
+1. Returns `400 Bad Request` if the request body is not valid JSON
+2. Returns `400 Bad Request` if the password does not meet requirements
+3. Returns `400 Bad Request` if the signup session token is invalid or expired
+4. Returns `409 Conflict` if the email address (from signup_sessions) is already registered in users table
+5. Creates a new user in the `users` table with hashed password
+6. Issues a JWT and sets it as an HTTP-only cookie
+7. Returns `200 OK`


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/signup/verify` endpoint to verify signup session and create user account
- Add password validation utilities (`utils/validation/index.ts`) with individual check functions for client-side UX
- Add JWT access token generation and cookie utilities (`utils/cookie/index.ts`)
- Add salt generation and password hashing functions (`utils/crypto/server.ts`)

## Test plan
- [x] Send valid request with correct token and password
- [x] Verify 400 response for invalid/expired token
- [x] Verify 400 response for weak password
- [x] Verify 409 response for already registered email
- [x] Verify JWT cookie is set on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)