### PR TITLE
Add POST /api/v1/login endpoint

### DIFF
--- a/app/consts.ts
+++ b/app/consts.ts
@@ -1,6 +1,9 @@
 export const OK = "OK";
 export const BAD_REQUEST = "Bad Request";
+export const UNAUTHORIZED = "Unauthorized";
+export const NOT_FOUND = "Not Found";
 export const CONFLICT = "Conflict";
+export const TOO_MANY_REQUESTS = "Too Many Requests";
 export const INTERNAL_SERVER_ERROR = "Internal Server Error";
 
 export const SIGNUP_SESSION_EXPIRATION_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -9,3 +12,7 @@ export const ACCESS_TOKEN_COOKIE_NAME = "access_token";
 export const ACCESS_TOKEN_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export const PASSWORD_MIN_LENGTH = 8;
+
+export const LOGIN_MAX_ATTEMPTS = 5;
+export const LOGIN_LOCK_DURATION_MS = 15 * 60 * 1000; // 15 minutes
+export const LOGIN_RATE_LIMIT_EXPIRATION_MS = 60 * 60 * 1000; // 1 hour

--- a/app/db/schemas.ts
+++ b/app/db/schemas.ts
@@ -34,3 +34,15 @@ export const signupSessionsTable = sqliteTable("signup_sessions", {
 	/** Expiration timestamp */
 	expiresAt: timestamp("expires_at").notNull(),
 });
+
+/** `login_rate_limits` table schema definition */
+export const loginRateLimitsTable = sqliteTable("login_rate_limits", {
+	/** Email address (primary key) */
+	email: text("email").primaryKey(),
+	/** Number of failed login attempts */
+	failedAttempts: integer("failed_attempts").notNull().default(0),
+	/** Timestamp until the account is locked */
+	lockedUntil: timestamp("locked_until"),
+	/** Expiration timestamp for this rate limit record */
+	expiresAt: timestamp("expires_at").notNull(),
+});

--- a/app/routes/api/v1/login/index.ts
+++ b/app/routes/api/v1/login/index.ts
@@ -1,0 +1,130 @@
+import { sValidator } from "@hono/standard-validator";
+import { eq } from "drizzle-orm";
+import { z } from "zod/v4";
+import {
+	BAD_REQUEST,
+	LOGIN_LOCK_DURATION_MS,
+	LOGIN_MAX_ATTEMPTS,
+	LOGIN_RATE_LIMIT_EXPIRATION_MS,
+	NOT_FOUND,
+	OK,
+	TOO_MANY_REQUESTS,
+	UNAUTHORIZED,
+} from "@/consts";
+import { getDBClient } from "@/db/client";
+import { loginRateLimitsTable, usersTable } from "@/db/schemas";
+import { generateAccessToken, setAccessTokenCookie } from "@/utils/cookie";
+import { hashPassword } from "@/utils/crypto/server";
+import { offsetMilliSeconds } from "@/utils/date";
+import { createHonoApp } from "@/utils/factory/hono";
+
+const jsonValidator = sValidator(
+	"json",
+	z.object({
+		email: z.email(),
+		password: z.string().min(1),
+	}),
+	(result, c) => {
+		if (!result.success) {
+			return c.text(BAD_REQUEST, 400);
+		}
+	},
+);
+
+export const route = createHonoApp().post("/", jsonValidator, async (c) => {
+	const { email, password } = c.req.valid("json");
+
+	const db = getDBClient(c.env.DB);
+
+	const user = await db
+		.select()
+		.from(usersTable)
+		.where(eq(usersTable.email, email))
+		.get();
+
+	if (!user) {
+		return c.text(NOT_FOUND, 404);
+	}
+
+	const now = new Date();
+
+	const rateLimit = await db
+		.select()
+		.from(loginRateLimitsTable)
+		.where(eq(loginRateLimitsTable.email, email))
+		.get();
+
+	if (rateLimit) {
+		if (rateLimit.expiresAt < now) {
+			await db
+				.delete(loginRateLimitsTable)
+				.where(eq(loginRateLimitsTable.email, email));
+		} else if (rateLimit.lockedUntil && rateLimit.lockedUntil > now) {
+			return c.text(TOO_MANY_REQUESTS, 429);
+		}
+	}
+
+	if (!user.salt || !user.passwordHash) {
+		return c.text(UNAUTHORIZED, 401);
+	}
+
+	const inputPasswordHash = hashPassword(password, user.salt);
+
+	if (inputPasswordHash !== user.passwordHash) {
+		const currentAttempts = rateLimit?.failedAttempts ?? 0;
+		const newAttempts = currentAttempts + 1;
+		const expiresAt = offsetMilliSeconds(now, LOGIN_RATE_LIMIT_EXPIRATION_MS);
+
+		if (newAttempts >= LOGIN_MAX_ATTEMPTS) {
+			const lockedUntil = offsetMilliSeconds(now, LOGIN_LOCK_DURATION_MS);
+			await db
+				.insert(loginRateLimitsTable)
+				.values({
+					email,
+					failedAttempts: newAttempts,
+					lockedUntil,
+					expiresAt,
+				})
+				.onConflictDoUpdate({
+					target: loginRateLimitsTable.email,
+					set: {
+						failedAttempts: newAttempts,
+						lockedUntil,
+						expiresAt,
+					},
+				});
+		} else {
+			await db
+				.insert(loginRateLimitsTable)
+				.values({
+					email,
+					failedAttempts: newAttempts,
+					expiresAt,
+				})
+				.onConflictDoUpdate({
+					target: loginRateLimitsTable.email,
+					set: {
+						failedAttempts: newAttempts,
+						expiresAt,
+					},
+				});
+		}
+
+		return c.text(UNAUTHORIZED, 401);
+	}
+
+	await db
+		.delete(loginRateLimitsTable)
+		.where(eq(loginRateLimitsTable.email, email));
+
+	const token = await generateAccessToken(
+		user.id,
+		user.email,
+		c.env.JWT_SECRET,
+	);
+	setAccessTokenCookie(c, token);
+
+	return c.text(OK, 200);
+});
+
+export default route;

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,6 +4,7 @@
 - [Endpoints](#Endpoints)
     - [`POST /api/v1/signup`](#POST-apiv1signup) : Create a new user account and send a verification email.
     - [`POST /api/v1/signup/verify`](#POST-apiv1signupverify) : Verify signup session and create user account.
+    - [`POST /api/v1/login`](#POST-apiv1login) : Authenticate user and issue JWT.
 
 ## Endpoints
 
@@ -45,5 +46,25 @@ type ResponseText = "OK" | "Bad Request" | "Conflict"
 3. Returns `400 Bad Request` if the signup session token is invalid or expired
 4. Returns `409 Conflict` if the email address (from signup_sessions) is already registered in users table
 5. Creates a new user in the `users` table with hashed password
+6. Issues a JWT and sets it as an HTTP-only cookie
+7. Returns `200 OK`
+
+### `POST /api/v1/login`
+
+```ts
+type RequestJSON = {
+    email: string;
+    password: string;
+}
+
+type ResponseText = "OK" | "Bad Request" | "Not Found" | "Unauthorized" | "Too Many Requests"
+```
+
+#### Flow
+1. Returns `400 Bad Request` if the request body is not valid JSON or email format is invalid
+2. Returns `404 Not Found` if the user does not exist
+3. Returns `429 Too Many Requests` if login attempts exceed the threshold
+4. Returns `401 Unauthorized` if the password is incorrect (increments failed attempts)
+5. Resets failed attempts on successful login
 6. Issues a JWT and sets it as an HTTP-only cookie
 7. Returns `200 OK`


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/login` endpoint with rate limiting
- Add `login_rate_limits` table schema for tracking failed login attempts
- Add rate limiting constants (`LOGIN_MAX_ATTEMPTS`, `LOGIN_LOCK_DURATION_MS`)

## Response Codes
- `400`: Invalid email format
- `404`: User not found
- `429`: Rate limit exceeded (5 failed attempts → 15min lock)
- `401`: Incorrect password
- `200`: Success with JWT cookie

## Test plan
- [x] Login with valid credentials
- [x] Verify 404 for non-existent user
- [x] Verify 401 for wrong password
- [x] Verify rate limiting after 5 failed attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)