### PR TITLE
feat: implement settings page with logout functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,14 @@ This is a user authentication sample application.
 ### Available commands
 All commands should be run inside the Docker container. From the host OS, prefix commands with:
 
-`docker exec -it user-auth-app bash -c "..."`
+`docker exec user-auth-app bash -c "..."`
+
+(Note: Use `docker exec` without `-it` flags when running from non-TTY environments)
+
+**Quick check (run before committing):**
+```
+docker exec user-auth-app bash -c "bun run biome && bun run tsc && bun run test:unit"
+```
 
 - `bun run biome` - Run Biome linter/formatter
 - `bun run tsc` - Run TypeScript type checker

--- a/app/islands/logout-button.tsx
+++ b/app/islands/logout-button.tsx
@@ -1,0 +1,37 @@
+import { useState } from "hono/jsx";
+import { apiClient } from "@/utils/api-client";
+
+export default function LogoutButton() {
+	const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+
+	const handleLogout = async () => {
+		setStatus("loading");
+
+		const response = await apiClient.v1.logout.$post();
+
+		if (response.ok) {
+			window.location.href = "/";
+			return;
+		}
+
+		setStatus("error");
+	};
+
+	return (
+		<div>
+			<button
+				type="button"
+				onClick={handleLogout}
+				disabled={status === "loading"}
+				class="px-4 py-2 bg-gray-500 text-white rounded cursor-pointer hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+			>
+				{status === "loading" ? "ログアウト中..." : "ログアウト"}
+			</button>
+			{status === "error" && (
+				<p class="mt-2 text-red-600 text-sm">
+					エラーが発生しました。再度お試しください
+				</p>
+			)}
+		</div>
+	);
+}

--- a/app/routes/api/v1/logout/index.ts
+++ b/app/routes/api/v1/logout/index.ts
@@ -1,0 +1,27 @@
+import { eq } from "drizzle-orm";
+import { OK } from "@/consts";
+import { getDBClient } from "@/db/client";
+import { loginSessionsTable } from "@/db/schemas";
+import { loginRequired } from "@/middlewares/auth";
+import { clearAuthCookies, getRefreshTokenFromCookie } from "@/utils/cookie";
+import { hashToken } from "@/utils/crypto/server";
+import { createHonoApp } from "@/utils/factory/hono";
+
+export const route = createHonoApp().post("/", loginRequired, async (c) => {
+	const refreshToken = await getRefreshTokenFromCookie(c);
+
+	if (refreshToken) {
+		const refreshTokenHash = hashToken(refreshToken);
+		const db = getDBClient(c.env.DB);
+
+		await db
+			.delete(loginSessionsTable)
+			.where(eq(loginSessionsTable.refreshTokenHash, refreshTokenHash));
+	}
+
+	clearAuthCookies(c);
+
+	return c.text(OK, 200);
+});
+
+export default route;

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -11,7 +11,14 @@ export default createRoute(optionalAuth, (c) => {
 				<div class="max-w-md w-full p-6 bg-white rounded-lg shadow-md">
 					<h1 class="text-2xl font-bold text-center mb-6">ホーム</h1>
 					{user ? (
-						<p class="text-center text-gray-700">ログイン中: {user.email}</p>
+						<div class="text-center space-y-2">
+							<p class="text-gray-700">ログイン中: {user.email}</p>
+							<p>
+								<a href="/settings" class="text-blue-600 hover:underline">
+									設定
+								</a>
+							</p>
+						</div>
 					) : (
 						<p class="text-center text-gray-600">
 							<a href="/login" class="text-blue-600 hover:underline">

--- a/app/routes/settings/index.tsx
+++ b/app/routes/settings/index.tsx
@@ -1,0 +1,33 @@
+import LogoutButton from "@/islands/logout-button";
+import { createAuthenticatedRoute } from "@/utils/factory/hono";
+
+export default createAuthenticatedRoute((c) => {
+	const user = c.get("user");
+
+	return c.render(
+		<>
+			<title>設定 | User Auth Example</title>
+			<div class="min-h-screen flex items-center justify-center bg-gray-50">
+				<div class="max-w-md w-full p-6 bg-white rounded-lg shadow-md">
+					<h1 class="text-2xl font-bold text-center mb-6">設定</h1>
+					<div class="space-y-4">
+						<div>
+							<span class="block text-sm font-medium text-gray-700">
+								メールアドレス
+							</span>
+							<p class="mt-1 text-gray-900">{user.email}</p>
+						</div>
+						<div class="pt-4 border-t border-gray-200">
+							<LogoutButton />
+						</div>
+					</div>
+					<p class="mt-6 text-center text-sm text-gray-600">
+						<a href="/" class="text-blue-600 hover:underline">
+							ホームに戻る
+						</a>
+					</p>
+				</div>
+			</div>
+		</>,
+	);
+});

--- a/app/utils/api-client/routes.ts
+++ b/app/utils/api-client/routes.ts
@@ -1,10 +1,12 @@
 import apiV1Login from "@/routes/api/v1/login";
+import apiV1Logout from "@/routes/api/v1/logout";
 import apiV1Signup from "@/routes/api/v1/signup";
 import apiV1SignupVerify from "@/routes/api/v1/signup/verify";
 import { createHonoApp } from "@/utils/factory/hono";
 
 const apiRoutes = createHonoApp()
 	.route("/api/v1/login", apiV1Login)
+	.route("/api/v1/logout", apiV1Logout)
 	.route("/api/v1/signup", apiV1Signup)
 	.route("/api/v1/signup/verify", apiV1SignupVerify);
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,6 +5,7 @@
     - [`POST /api/v1/signup`](#POST-apiv1signup) : Create a new user account and send a verification email.
     - [`POST /api/v1/signup/verify`](#POST-apiv1signupverify) : Verify signup session and create user account.
     - [`POST /api/v1/login`](#POST-apiv1login) : Authenticate user and issue JWT.
+    - [`POST /api/v1/logout`](#POST-apiv1logout) : Clear authentication cookies and invalidate session.
 
 ## Endpoints
 
@@ -68,3 +69,15 @@ type ResponseText = "OK" | "Bad Request" | "Not Found" | "Unauthorized" | "Too M
 5. Resets failed attempts on successful login
 6. Issues a JWT and sets it as an HTTP-only cookie
 7. Returns `200 OK`
+
+### `POST /api/v1/logout`
+
+```ts
+type ResponseText = "OK" | "Unauthorized"
+```
+
+#### Flow
+1. Returns `401 Unauthorized` if not authenticated
+2. Deletes the current login session from `login_sessions` table
+3. Clears access token and refresh token cookies
+4. Returns `200 OK`

--- a/docs/PAGE.md
+++ b/docs/PAGE.md
@@ -2,27 +2,32 @@
 
 ## Table of Contents
 - [Pages](#Pages)
-    - [`/`](#root) : Home page (requires login)
+    - [`/`](#root) : Home page
     - [`/login`](#login) : User login page
     - [`/signup`](#signup) : User registration page
     - [`/signup/verify`](#signupverify) : Password setup page after email verification
+    - [`/settings`](#settings) : User settings page (requires login)
 
 ## Pages
 
 ### `/`
 
-Home page for authenticated users.
+Home page with different content based on authentication status.
 
 #### Middleware
-- `login_required` - Redirects to `/login` if not authenticated
+- `optionalAuth` - Continues regardless of auth status
 
-#### Components
+#### Components (Authenticated)
 - User's email address display
+- Link to settings page (`/settings`)
+
+#### Components (Not Authenticated)
+- Link to login page (`/login`)
 
 #### Behavior
-1. `login_required` middleware validates authentication
-2. If validation fails: Redirects to `/login`
-3. If validation succeeds: Displays user's email address
+1. `optionalAuth` middleware checks authentication
+2. If authenticated: Displays user's email address and settings link
+3. If not authenticated: Displays login link
 
 ### `/login`
 
@@ -79,3 +84,22 @@ Password setup page accessed via email verification link ( `/signup/verify?token
 6. Calls `POST /api/v1/signup/verify` with token and password
 7. On success (200): Redirects to `/`
 8. On error: Displays appropriate error message
+
+### `/settings`
+
+User settings page for managing account.
+
+#### Middleware
+- `createAuthenticatedRoute` - Redirects to `/login?redirect=%2Fsettings` if not authenticated
+
+#### Components
+- User's email address display
+- Logout button
+
+#### Behavior
+1. `createAuthenticatedRoute` middleware validates authentication
+2. If validation fails: Redirects to `/login?redirect=%2Fsettings`
+3. If validation succeeds: Displays user's email address and logout button
+4. User clicks logout button
+5. Calls `POST /api/v1/logout`
+6. On success (200): Redirects to `/`


### PR DESCRIPTION
## Summary
- Add POST /api/v1/logout endpoint to clear auth cookies and invalidate session
- Add /settings page with user email display and logout button
- Add settings link to home page for authenticated users
- Update documentation (API.md, PAGE.md, AGENTS.md)

## Test plan
- [x] Login and verify settings link appears on home page
- [x] Navigate to /settings and verify email is displayed
- [x] Click logout button and verify redirect to /
- [x] Verify cookies are cleared after logout
- [x] Try accessing /settings without auth and verify redirect to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)