### PR TITLE
feat: add remember me checkbox to login form

### DIFF
--- a/app/islands/login-form.tsx
+++ b/app/islands/login-form.tsx
@@ -4,6 +4,7 @@ import { apiClient } from "@/utils/api-client";
 export default function LoginForm() {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
+	const [rememberMe, setRememberMe] = useState(true);
 	const [status, setStatus] = useState<
 		"idle" | "loading" | "success" | "error"
 	>("idle");
@@ -15,7 +16,7 @@ export default function LoginForm() {
 		setErrorMessage("");
 
 		const response = await apiClient.v1.login.$post({
-			json: { email, password },
+			json: { email, password, rememberMe },
 		});
 
 		if (response.ok) {
@@ -77,6 +78,21 @@ export default function LoginForm() {
 					required
 					disabled={status === "loading"}
 				/>
+			</div>
+			<div class="flex items-center">
+				<input
+					type="checkbox"
+					id="rememberMe"
+					checked={rememberMe}
+					onChange={(e) =>
+						setRememberMe((e.target as HTMLInputElement).checked)
+					}
+					class="h-4 w-4 text-orange-500 focus:ring-orange-500 border-gray-300 rounded"
+					disabled={status === "loading"}
+				/>
+				<label for="rememberMe" class="ml-2 block text-sm text-gray-700">
+					ログイン状態を保持する
+				</label>
 			</div>
 			{status === "error" && <p class="text-red-600 text-sm">{errorMessage}</p>}
 			<button

--- a/app/routes/api/v1/login/index.ts
+++ b/app/routes/api/v1/login/index.ts
@@ -37,6 +37,7 @@ const jsonValidator = sValidator(
 	z.object({
 		email: z.email(),
 		password: z.string().min(1),
+		rememberMe: z.boolean().optional().default(true),
 	}),
 	(result, c) => {
 		if (!result.success) {
@@ -46,7 +47,7 @@ const jsonValidator = sValidator(
 );
 
 export const route = createHonoApp().post("/", jsonValidator, async (c) => {
-	const { email, password } = c.req.valid("json");
+	const { email, password, rememberMe } = c.req.valid("json");
 
 	const db = getDBClient(c.env.DB);
 
@@ -152,7 +153,7 @@ export const route = createHonoApp().post("/", jsonValidator, async (c) => {
 		expiresAt,
 	});
 
-	setRefreshTokenCookie(c, refreshToken);
+	setRefreshTokenCookie(c, refreshToken, rememberMe);
 
 	return c.text(OK, 200);
 });

--- a/app/utils/cookie/index.ts
+++ b/app/utils/cookie/index.ts
@@ -80,15 +80,25 @@ export function setAccessTokenCookie(c: Context, token: string): void {
  *
  * @param c - The Hono context
  * @param token - The refresh token to set
+ * @param rememberMe - If true (default), sets maxAge for persistent cookie; if false, creates session cookie
  */
-export function setRefreshTokenCookie(c: Context, token: string): void {
-	setCookie(c, REFRESH_TOKEN_COOKIE_NAME, token, {
+export function setRefreshTokenCookie(
+	c: Context,
+	token: string,
+	rememberMe = true,
+): void {
+	const cookieOptions: Parameters<typeof setCookie>[3] = {
 		httpOnly: true,
 		secure: true,
 		sameSite: "Strict",
 		path: "/",
-		maxAge: Math.floor(REFRESH_TOKEN_EXPIRATION_MS / 1000),
-	});
+	};
+
+	if (rememberMe) {
+		cookieOptions.maxAge = Math.floor(REFRESH_TOKEN_EXPIRATION_MS / 1000);
+	}
+
+	setCookie(c, REFRESH_TOKEN_COOKIE_NAME, token, cookieOptions);
 }
 
 /**

--- a/docs/API.md
+++ b/docs/API.md
@@ -56,6 +56,7 @@ type ResponseText = "OK" | "Bad Request" | "Conflict"
 type RequestJSON = {
     email: string;
     password: string;
+    rememberMe?: boolean; // default: true
 }
 
 type ResponseText = "OK" | "Bad Request" | "Not Found" | "Unauthorized" | "Too Many Requests"
@@ -67,7 +68,9 @@ type ResponseText = "OK" | "Bad Request" | "Not Found" | "Unauthorized" | "Too M
 3. Returns `429 Too Many Requests` if login attempts exceed the threshold
 4. Returns `401 Unauthorized` if the password is incorrect (increments failed attempts)
 5. Resets failed attempts on successful login
-6. Issues a JWT and sets it as an HTTP-only cookie
+6. Issues access token (15 min) and refresh token as HTTP-only cookies
+    - If `rememberMe` is true (default): refresh token has 30-day expiration
+    - If `rememberMe` is false: refresh token is a session cookie (deleted when browser closes)
 7. Returns `200 OK`
 
 ### `POST /api/v1/logout`


### PR DESCRIPTION
## Summary
- Add "remember me" checkbox to login form (checked by default)
- When checked: refresh token set as persistent cookie (30 days)
- When unchecked: refresh token set as session cookie (deleted when browser closes)

## Changes
- `app/utils/cookie/index.ts` - Add `rememberMe` parameter to `setRefreshTokenCookie`
- `app/routes/api/v1/login/index.ts` - Accept `rememberMe` in request body
- `app/islands/login-form.tsx` - Add checkbox UI
- `docs/API.md` - Document new parameter

## Test plan
- [x] Login with checkbox checked - verify cookie has Max-Age (30 days)
- [x] Login with checkbox unchecked - verify cookie shows "Session" in DevTools
- [x] Close and reopen browser with session cookie - verify logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)