### PR TITLE
Add temporary session token for rememberMe=false

### DIFF
--- a/app/consts.ts
+++ b/app/consts.ts
@@ -14,6 +14,9 @@ export const ACCESS_TOKEN_EXPIRATION_MS = 15 * 60 * 1000; // 15 minutes
 export const REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
 export const REFRESH_TOKEN_EXPIRATION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
+export const TEMP_SESSION_COOKIE_NAME = "temp_session";
+export const TEMP_SESSION_IDLE_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours (for cleanup)
+
 export const PASSWORD_MIN_LENGTH = 8;
 
 export const LOGIN_MAX_ATTEMPTS = 5;

--- a/app/db/schemas.ts
+++ b/app/db/schemas.ts
@@ -64,3 +64,19 @@ export const loginSessionsTable = sqliteTable("login_sessions", {
 	/** Expiration timestamp */
 	expiresAt: timestamp("expires_at").notNull(),
 });
+
+/** `temporary_sessions` table schema definition (for rememberMe=false) */
+export const temporarySessionsTable = sqliteTable("temporary_sessions", {
+	/** UUIDv7 */
+	id: text("id").primaryKey(),
+	/** User ID (foreign key to users table) */
+	userId: text("user_id").notNull(),
+	/** SHA-256 hash of the session token */
+	sessionTokenHash: text("session_token_hash").notNull().unique(),
+	/** Client user agent string */
+	userAgent: text("user_agent"),
+	/** Timestamp of session creation */
+	createdAt: timestamp("created_at").notNull().default(now()),
+	/** Timestamp of last access (for cleanup purposes) */
+	lastAccessedAt: timestamp("last_accessed_at").notNull().default(now()),
+});

--- a/app/islands/login-form.tsx
+++ b/app/islands/login-form.tsx
@@ -94,6 +94,11 @@ export default function LoginForm() {
 					ログイン状態を保持する
 				</label>
 			</div>
+			{!rememberMe && (
+				<p class="text-xs text-gray-500">
+					ブラウザの設定によっては、ブラウザを閉じてもログイン状態が維持される場合があります。共有のパソコンをお使いの場合など、確実にログアウトしたい場合は設定画面から手動でログアウトすることをおすすめします。
+				</p>
+			)}
 			{status === "error" && <p class="text-red-600 text-sm">{errorMessage}</p>}
 			<button
 				type="submit"

--- a/app/routes/api/v1/logout/index.ts
+++ b/app/routes/api/v1/logout/index.ts
@@ -1,22 +1,35 @@
 import { eq } from "drizzle-orm";
 import { OK } from "@/consts";
 import { getDBClient } from "@/db/client";
-import { loginSessionsTable } from "@/db/schemas";
+import { loginSessionsTable, temporarySessionsTable } from "@/db/schemas";
 import { loginRequired } from "@/middlewares/auth";
-import { clearAuthCookies, getRefreshTokenFromCookie } from "@/utils/cookie";
+import {
+	clearAuthCookies,
+	getRefreshTokenFromCookie,
+	getTempSessionTokenFromCookie,
+} from "@/utils/cookie";
 import { hashToken } from "@/utils/crypto/server";
 import { createHonoApp } from "@/utils/factory/hono";
 
 export const route = createHonoApp().post("/", loginRequired, async (c) => {
-	const refreshToken = await getRefreshTokenFromCookie(c);
+	const db = getDBClient(c.env.DB);
 
+	// Handle refresh token session (rememberMe=true)
+	const refreshToken = await getRefreshTokenFromCookie(c);
 	if (refreshToken) {
 		const refreshTokenHash = hashToken(refreshToken);
-		const db = getDBClient(c.env.DB);
-
 		await db
 			.delete(loginSessionsTable)
 			.where(eq(loginSessionsTable.refreshTokenHash, refreshTokenHash));
+	}
+
+	// Handle temporary session (rememberMe=false)
+	const tempSessionToken = getTempSessionTokenFromCookie(c);
+	if (tempSessionToken) {
+		const sessionTokenHash = hashToken(tempSessionToken);
+		await db
+			.delete(temporarySessionsTable)
+			.where(eq(temporarySessionsTable.sessionTokenHash, sessionTokenHash));
 	}
 
 	clearAuthCookies(c);

--- a/app/utils/cookie/index.ts
+++ b/app/utils/cookie/index.ts
@@ -7,6 +7,7 @@ import {
 	ACCESS_TOKEN_EXPIRATION_MS,
 	REFRESH_TOKEN_COOKIE_NAME,
 	REFRESH_TOKEN_EXPIRATION_MS,
+	TEMP_SESSION_COOKIE_NAME,
 } from "@/consts";
 import { generateSecureToken, hashToken } from "@/utils/crypto/server";
 import { offsetMilliSeconds } from "@/utils/date";
@@ -144,6 +145,33 @@ export async function getRefreshTokenFromCookie(
 }
 
 /**
+ * Sets the temporary session cookie (session cookie - no maxAge).
+ *
+ * @param c - The Hono context
+ * @param token - The temporary session token to set
+ */
+export function setTempSessionCookie(c: Context, token: string): void {
+	setCookie(c, TEMP_SESSION_COOKIE_NAME, token, {
+		httpOnly: true,
+		secure: true,
+		sameSite: "Strict",
+		path: "/",
+		// No maxAge = session cookie (deleted when browser closes)
+	});
+}
+
+/**
+ * Retrieves the temporary session token from the cookie.
+ *
+ * @param c - The Hono context
+ * @returns The temporary session token if present, null otherwise
+ */
+export function getTempSessionTokenFromCookie(c: Context): string | null {
+	const token = getCookie(c, TEMP_SESSION_COOKIE_NAME);
+	return token ?? null;
+}
+
+/**
  * Clears authentication cookies.
  *
  * @param c - The Hono context
@@ -151,4 +179,5 @@ export async function getRefreshTokenFromCookie(
 export function clearAuthCookies(c: Context): void {
 	deleteCookie(c, ACCESS_TOKEN_COOKIE_NAME, { path: "/" });
 	deleteCookie(c, REFRESH_TOKEN_COOKIE_NAME, { path: "/" });
+	deleteCookie(c, TEMP_SESSION_COOKIE_NAME, { path: "/" });
 }


### PR DESCRIPTION
## Summary
- Implement separate authentication flow for `rememberMe=false` using temporary session tokens
- Add warning message in login form when checkbox is unchecked
- Support both persistent (rememberMe=true) and temporary (rememberMe=false) session types

## Changes
- **DB Schema**: Add `temporarySessionsTable` for storing temporary sessions
- **Constants**: Add `TEMP_SESSION_COOKIE_NAME` and `TEMP_SESSION_IDLE_TIMEOUT_MS`
- **Cookie Utils**: Add `setTempSessionCookie` and `getTempSessionTokenFromCookie`
- **Login**: Branch logic based on `rememberMe` value
- **Auth Middleware**: Validate temporary session tokens
- **Logout**: Handle both session types
- **Login Form**: Show warning when rememberMe is unchecked

## Test plan
- [x] Login with rememberMe=true → verify access_token and refresh_token cookies
- [x] Login with rememberMe=false → verify only temp_session cookie
- [x] Access protected route with both session types
- [x] Logout and verify session is deleted from DB

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)