### PR TITLE
Add JSDoc and tests for password validation functions

### DIFF
--- a/app/db/drizzle/meta/0000_snapshot.json
+++ b/app/db/drizzle/meta/0000_snapshot.json
@@ -1,302 +1,292 @@
 {
-  "version": "6",
-  "dialect": "sqlite",
-  "id": "bc28eca7-494d-4d6c-be4c-25ae456afe99",
-  "prevId": "00000000-0000-0000-0000-000000000000",
-  "tables": {
-    "login_rate_limits": {
-      "name": "login_rate_limits",
-      "columns": {
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "failed_attempts": {
-          "name": "failed_attempts",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": 0
-        },
-        "locked_until": {
-          "name": "locked_until",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
-    "login_sessions": {
-      "name": "login_sessions",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "refresh_token_hash": {
-          "name": "refresh_token_hash",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(unixepoch())"
-        },
-        "last_accessed_at": {
-          "name": "last_accessed_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(unixepoch())"
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "login_sessions_refresh_token_hash_unique": {
-          "name": "login_sessions_refresh_token_hash_unique",
-          "columns": [
-            "refresh_token_hash"
-          ],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
-    "signup_sessions": {
-      "name": "signup_sessions",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "token_hash": {
-          "name": "token_hash",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {
-        "signup_sessions_token_hash_unique": {
-          "name": "signup_sessions_token_hash_unique",
-          "columns": [
-            "token_hash"
-          ],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
-    "temporary_sessions": {
-      "name": "temporary_sessions",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "session_token_hash": {
-          "name": "session_token_hash",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(unixepoch())"
-        },
-        "last_accessed_at": {
-          "name": "last_accessed_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(unixepoch())"
-        }
-      },
-      "indexes": {
-        "temporary_sessions_session_token_hash_unique": {
-          "name": "temporary_sessions_session_token_hash_unique",
-          "columns": [
-            "session_token_hash"
-          ],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
-    "users": {
-      "name": "users",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "salt": {
-          "name": "salt",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "password_hash": {
-          "name": "password_hash",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "google_id": {
-          "name": "google_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "(unixepoch())"
-        }
-      },
-      "indexes": {
-        "users_email_unique": {
-          "name": "users_email_unique",
-          "columns": [
-            "email"
-          ],
-          "isUnique": true
-        },
-        "users_google_id_unique": {
-          "name": "users_google_id_unique",
-          "columns": [
-            "google_id"
-          ],
-          "isUnique": true
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    }
-  },
-  "views": {},
-  "enums": {},
-  "_meta": {
-    "schemas": {},
-    "tables": {},
-    "columns": {}
-  },
-  "internal": {
-    "indexes": {}
-  }
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "bc28eca7-494d-4d6c-be4c-25ae456afe99",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"tables": {
+		"login_rate_limits": {
+			"name": "login_rate_limits",
+			"columns": {
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"failed_attempts": {
+					"name": "failed_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"locked_until": {
+					"name": "locked_until",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"login_sessions": {
+			"name": "login_sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"refresh_token_hash": {
+					"name": "refresh_token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch())"
+				},
+				"last_accessed_at": {
+					"name": "last_accessed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch())"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"login_sessions_refresh_token_hash_unique": {
+					"name": "login_sessions_refresh_token_hash_unique",
+					"columns": ["refresh_token_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"signup_sessions": {
+			"name": "signup_sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"signup_sessions_token_hash_unique": {
+					"name": "signup_sessions_token_hash_unique",
+					"columns": ["token_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"temporary_sessions": {
+			"name": "temporary_sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_token_hash": {
+					"name": "session_token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch())"
+				},
+				"last_accessed_at": {
+					"name": "last_accessed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch())"
+				}
+			},
+			"indexes": {
+				"temporary_sessions_session_token_hash_unique": {
+					"name": "temporary_sessions_session_token_hash_unique",
+					"columns": ["session_token_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"salt": {
+					"name": "salt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"google_id": {
+					"name": "google_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch())"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				},
+				"users_google_id_unique": {
+					"name": "users_google_id_unique",
+					"columns": ["google_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
 }

--- a/app/db/drizzle/meta/_journal.json
+++ b/app/db/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-  "version": "7",
-  "dialect": "sqlite",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "6",
-      "when": 1769439394780,
-      "tag": "0000_create_tables",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1769439394780,
+			"tag": "0000_create_tables",
+			"breakpoints": true
+		}
+	]
 }

--- a/app/utils/validation/index.spec.ts
+++ b/app/utils/validation/index.spec.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "bun:test";
+import {
+	checkPasswordHasLowercase,
+	checkPasswordHasNumber,
+	checkPasswordHasSymbol,
+	checkPasswordHasThreeTypes,
+	checkPasswordHasUppercase,
+	checkPasswordMinLength,
+	checkPasswordNotSimilarToEmail,
+	validatePassword,
+} from "./index";
+
+describe("checkPasswordMinLength", () => {
+	it("should return true for password with exactly 8 characters", () => {
+		const result = checkPasswordMinLength("12345678");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return true for password longer than 8 characters", () => {
+		const result = checkPasswordMinLength("123456789");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false for password with 7 characters", () => {
+		const result = checkPasswordMinLength("1234567");
+
+		expect(result).toBe(false);
+	});
+
+	it("should return false for empty password", () => {
+		const result = checkPasswordMinLength("");
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("checkPasswordHasLowercase", () => {
+	it("should return true for password with lowercase letter", () => {
+		const result = checkPasswordHasLowercase("Password");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false for password without lowercase letter", () => {
+		const result = checkPasswordHasLowercase("PASSWORD123");
+
+		expect(result).toBe(false);
+	});
+
+	it("should return false for empty password", () => {
+		const result = checkPasswordHasLowercase("");
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("checkPasswordHasUppercase", () => {
+	it("should return true for password with uppercase letter", () => {
+		const result = checkPasswordHasUppercase("Password");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false for password without uppercase letter", () => {
+		const result = checkPasswordHasUppercase("password123");
+
+		expect(result).toBe(false);
+	});
+
+	it("should return false for empty password", () => {
+		const result = checkPasswordHasUppercase("");
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("checkPasswordHasNumber", () => {
+	it("should return true for password with number", () => {
+		const result = checkPasswordHasNumber("Password1");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false for password without number", () => {
+		const result = checkPasswordHasNumber("Password");
+
+		expect(result).toBe(false);
+	});
+
+	it("should return false for empty password", () => {
+		const result = checkPasswordHasNumber("");
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("checkPasswordHasSymbol", () => {
+	it("should return true for password with symbol", () => {
+		const result = checkPasswordHasSymbol("Password!");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return true for password with various symbols", () => {
+		expect(checkPasswordHasSymbol("pass@word")).toBe(true);
+		expect(checkPasswordHasSymbol("pass#word")).toBe(true);
+		expect(checkPasswordHasSymbol("pass$word")).toBe(true);
+		expect(checkPasswordHasSymbol("pass_word")).toBe(true);
+		expect(checkPasswordHasSymbol("pass-word")).toBe(true);
+	});
+
+	it("should return false for password without symbol", () => {
+		const result = checkPasswordHasSymbol("Password123");
+
+		expect(result).toBe(false);
+	});
+
+	it("should return false for empty password", () => {
+		const result = checkPasswordHasSymbol("");
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("checkPasswordHasThreeTypes", () => {
+	it("should return true for password with lowercase, uppercase, and number", () => {
+		const result = checkPasswordHasThreeTypes("Password1");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return true for password with lowercase, uppercase, and symbol", () => {
+		const result = checkPasswordHasThreeTypes("Password!");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return true for password with lowercase, number, and symbol", () => {
+		const result = checkPasswordHasThreeTypes("password1!");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return true for password with uppercase, number, and symbol", () => {
+		const result = checkPasswordHasThreeTypes("PASSWORD1!");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return true for password with all four types", () => {
+		const result = checkPasswordHasThreeTypes("Password1!");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false for password with only two types", () => {
+		expect(checkPasswordHasThreeTypes("password1")).toBe(false);
+		expect(checkPasswordHasThreeTypes("Password")).toBe(false);
+		expect(checkPasswordHasThreeTypes("12345678")).toBe(false);
+	});
+
+	it("should return false for password with only one type", () => {
+		expect(checkPasswordHasThreeTypes("password")).toBe(false);
+		expect(checkPasswordHasThreeTypes("PASSWORD")).toBe(false);
+	});
+
+	it("should return false for empty password", () => {
+		const result = checkPasswordHasThreeTypes("");
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("checkPasswordNotSimilarToEmail", () => {
+	it("should return true when password does not contain email local part", () => {
+		const result = checkPasswordNotSimilarToEmail(
+			"SecurePass1!",
+			"user@example.com",
+		);
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false when password contains email local part", () => {
+		const result = checkPasswordNotSimilarToEmail(
+			"userPassword1!",
+			"user@example.com",
+		);
+
+		expect(result).toBe(false);
+	});
+
+	it("should be case-insensitive", () => {
+		const result = checkPasswordNotSimilarToEmail(
+			"USERPassword1!",
+			"user@example.com",
+		);
+
+		expect(result).toBe(false);
+	});
+
+	it("should return true when email local part is less than 3 characters", () => {
+		const result = checkPasswordNotSimilarToEmail(
+			"abPassword1!",
+			"ab@example.com",
+		);
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false when password contains email local part of exactly 3 characters", () => {
+		const result = checkPasswordNotSimilarToEmail(
+			"abcPassword1!",
+			"abc@example.com",
+		);
+
+		expect(result).toBe(false);
+	});
+
+	it("should handle email without @ symbol", () => {
+		const result = checkPasswordNotSimilarToEmail(
+			"SecurePass1!",
+			"invalidEmail",
+		);
+
+		expect(result).toBe(true);
+	});
+
+	it("should handle empty email", () => {
+		const result = checkPasswordNotSimilarToEmail("SecurePass1!", "");
+
+		expect(result).toBe(true);
+	});
+});
+
+describe("validatePassword", () => {
+	it("should return valid for password meeting all requirements", () => {
+		const result = validatePassword("SecurePass1!", "user@example.com");
+
+		expect(result.isValid).toBe(true);
+		expect(result.isMinLength).toBe(true);
+		expect(result.hasLowercase).toBe(true);
+		expect(result.hasUppercase).toBe(true);
+		expect(result.hasNumber).toBe(true);
+		expect(result.hasSymbol).toBe(true);
+		expect(result.hasThreeTypes).toBe(true);
+		expect(result.isNotSimilarToEmail).toBe(true);
+	});
+
+	it("should return invalid for password too short", () => {
+		const result = validatePassword("Pass1!", "user@example.com");
+
+		expect(result.isValid).toBe(false);
+		expect(result.isMinLength).toBe(false);
+	});
+
+	it("should return invalid for password with only two character types", () => {
+		const result = validatePassword("password12", "user@example.com");
+
+		expect(result.isValid).toBe(false);
+		expect(result.hasThreeTypes).toBe(false);
+	});
+
+	it("should return invalid for password similar to email", () => {
+		const result = validatePassword("userPass1!", "user@example.com");
+
+		expect(result.isValid).toBe(false);
+		expect(result.isNotSimilarToEmail).toBe(false);
+	});
+
+	it("should return all individual check results", () => {
+		const result = validatePassword("abcdefgh", "user@example.com");
+
+		expect(result.isMinLength).toBe(true);
+		expect(result.hasLowercase).toBe(true);
+		expect(result.hasUppercase).toBe(false);
+		expect(result.hasNumber).toBe(false);
+		expect(result.hasSymbol).toBe(false);
+		expect(result.hasThreeTypes).toBe(false);
+		expect(result.isNotSimilarToEmail).toBe(true);
+		expect(result.isValid).toBe(false);
+	});
+
+	it("should handle empty password", () => {
+		const result = validatePassword("", "user@example.com");
+
+		expect(result.isValid).toBe(false);
+		expect(result.isMinLength).toBe(false);
+		expect(result.hasThreeTypes).toBe(false);
+	});
+});

--- a/app/utils/validation/index.ts
+++ b/app/utils/validation/index.ts
@@ -1,5 +1,6 @@
 import { PASSWORD_MIN_LENGTH } from "@/consts";
 
+/** Result of password validation containing individual check results */
 export type PasswordValidationResult = {
 	isMinLength: boolean;
 	hasLowercase: boolean;
@@ -11,26 +12,63 @@ export type PasswordValidationResult = {
 	isValid: boolean;
 };
 
+/**
+ * Checks if the password meets the minimum length requirement.
+ *
+ * @param password - The password to validate
+ * @returns True if the password length is at least PASSWORD_MIN_LENGTH (8 characters)
+ */
 export function checkPasswordMinLength(password: string): boolean {
 	return password.length >= PASSWORD_MIN_LENGTH;
 }
 
+/**
+ * Checks if the password contains at least one lowercase letter (a-z).
+ *
+ * @param password - The password to validate
+ * @returns True if the password contains a lowercase letter
+ */
 export function checkPasswordHasLowercase(password: string): boolean {
 	return /[a-z]/.test(password);
 }
 
+/**
+ * Checks if the password contains at least one uppercase letter (A-Z).
+ *
+ * @param password - The password to validate
+ * @returns True if the password contains an uppercase letter
+ */
 export function checkPasswordHasUppercase(password: string): boolean {
 	return /[A-Z]/.test(password);
 }
 
+/**
+ * Checks if the password contains at least one numeric digit (0-9).
+ *
+ * @param password - The password to validate
+ * @returns True if the password contains a number
+ */
 export function checkPasswordHasNumber(password: string): boolean {
 	return /[0-9]/.test(password);
 }
 
+/**
+ * Checks if the password contains at least one symbol (non-alphanumeric character).
+ *
+ * @param password - The password to validate
+ * @returns True if the password contains a symbol
+ */
 export function checkPasswordHasSymbol(password: string): boolean {
 	return /[^a-zA-Z0-9]/.test(password);
 }
 
+/**
+ * Checks if the password contains at least three different character types.
+ * Character types: lowercase, uppercase, numbers, symbols.
+ *
+ * @param password - The password to validate
+ * @returns True if the password contains at least 3 of the 4 character types
+ */
 export function checkPasswordHasThreeTypes(password: string): boolean {
 	let typeCount = 0;
 	if (checkPasswordHasLowercase(password)) typeCount++;
@@ -40,6 +78,15 @@ export function checkPasswordHasThreeTypes(password: string): boolean {
 	return typeCount >= 3;
 }
 
+/**
+ * Checks if the password is not similar to the email address.
+ * Returns false if the email's local part (before @) is 3+ characters
+ * and the password contains it (case-insensitive).
+ *
+ * @param password - The password to validate
+ * @param email - The user's email address
+ * @returns True if the password does not contain the email's local part
+ */
 export function checkPasswordNotSimilarToEmail(
 	password: string,
 	email: string,
@@ -54,6 +101,17 @@ export function checkPasswordNotSimilarToEmail(
 	return true;
 }
 
+/**
+ * Validates a password against all security requirements.
+ * A valid password must:
+ * - Be at least 8 characters long
+ * - Contain at least 3 of 4 character types (lowercase, uppercase, numbers, symbols)
+ * - Not contain the email's local part (if 3+ characters)
+ *
+ * @param password - The password to validate
+ * @param email - The user's email address for similarity check
+ * @returns Object containing individual check results and overall validity
+ */
 export function validatePassword(
 	password: string,
 	email: string,


### PR DESCRIPTION
## Summary
- Add JSDoc comments to all password validation functions
- Add comprehensive unit tests for validation functions

## Changes
- **validation/index.ts**: Add JSDoc comments with @param and @returns for all 8 functions
- **validation/index.spec.ts**: Add 38 unit tests covering all validation functions

## Test plan
- [x] All 60 unit tests pass (`bun run test:unit`)
- [x] Type checking passes (`bun run tsc`)
- [x] Linting passes (`bun run biome`)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)