### PR TITLE
feat: add signup link to top page (#29)

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -20,12 +20,20 @@ export default createRoute(optionalAuth, (c) => {
 							</p>
 						</div>
 					) : (
-						<p class="text-center text-gray-600">
-							<a href="/login" class="text-blue-600 hover:underline">
-								ログイン
-							</a>
-							してください
-						</p>
+						<div class="text-center space-y-2">
+							<p class="text-gray-600">
+								<a href="/login" class="text-blue-600 hover:underline">
+									ログイン
+								</a>
+								してください
+							</p>
+							<p class="text-gray-600">
+								アカウントをお持ちでない方は
+								<a href="/signup" class="text-blue-600 hover:underline">
+									新規登録
+								</a>
+							</p>
+						</div>
 					)}
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Add signup link to the top page for users who are not logged in
- Display "アカウントをお持ちでない方は新規登録" message with link to /signup

Closes #29

## Test plan
- [x] Verify the signup link appears on the top page when not logged in
- [x] Verify clicking the signup link navigates to /signup
- [x] Verify the login link still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)