### PR TITLE
feat: add global dark mode toggle to settings page (#38)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ This is a user authentication sample application.
 ## Working with GitHub
 For all GitHub operations (creating issues, pull requests, searching code, etc.), use `gh` command.
 
+### General guidelines
+- Do not add comments to GitHub issues unless explicitly instructed
+- Do not edit existing issues unless explicitly instructed
+
 ### Creating issues
 - Use clear, descriptive titles starting with a verb (e.g., "Add", "Fix", "Update")
 - Structure the description with:

--- a/app/islands/dark-mode-switch.tsx
+++ b/app/islands/dark-mode-switch.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "hono/jsx";
+import type { JSX } from "hono/jsx/jsx-runtime";
+import Switch from "./switch";
+
+const STORAGE_KEY = "theme";
+
+export default function DarkModeSwitch(): JSX.Element {
+	const [initialized, setInitialized] = useState(false);
+	const [isDark, setIsDark] = useState(false);
+
+	useEffect(() => {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		const prefersDark = window.matchMedia(
+			"(prefers-color-scheme: dark)",
+		).matches;
+		const initialDark = stored ? stored === "dark" : prefersDark;
+
+		setIsDark(initialDark);
+		applyTheme(initialDark);
+		setInitialized(true);
+	}, []);
+
+	const applyTheme = (dark: boolean) => {
+		if (dark) {
+			document.documentElement.classList.add("dark");
+		} else {
+			document.documentElement.classList.remove("dark");
+		}
+	};
+
+	const handleChange = (checked: boolean) => {
+		setIsDark(checked);
+		applyTheme(checked);
+		localStorage.setItem(STORAGE_KEY, checked ? "dark" : "light");
+	};
+
+	if (!initialized) {
+		return (
+			<div class="flex items-center justify-between">
+				<span class="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+					ダークモード
+				</span>
+				<div class="h-6 w-11" />
+			</div>
+		);
+	}
+
+	return (
+		<div class="flex items-center justify-between">
+			<span class="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+				ダークモード
+			</span>
+			<Switch
+				id="dark-mode-switch"
+				defaultChecked={isDark}
+				onChange={handleChange}
+			/>
+		</div>
+	);
+}

--- a/app/routes/components/switch.tsx
+++ b/app/routes/components/switch.tsx
@@ -38,11 +38,19 @@ export default createRoute((c) => {
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">Disabled Off</span>
-									<Switch id="default-disabled-off" defaultChecked={false} disabled />
+									<Switch
+										id="default-disabled-off"
+										defaultChecked={false}
+										disabled
+									/>
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">Disabled On</span>
-									<Switch id="default-disabled-on" defaultChecked={true} disabled />
+									<Switch
+										id="default-disabled-on"
+										defaultChecked={true}
+										disabled
+									/>
 								</div>
 							</div>
 						</section>
@@ -54,11 +62,19 @@ export default createRoute((c) => {
 							<div class="space-y-4 p-6 rounded-lg border border-emerald-200 dark:border-emerald-800">
 								<div class="flex items-center justify-between">
 									<span class="text-sm">Off State</span>
-									<Switch id="primary-off" defaultChecked={false} color="primary" />
+									<Switch
+										id="primary-off"
+										defaultChecked={false}
+										color="primary"
+									/>
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">On State</span>
-									<Switch id="primary-on" defaultChecked={true} color="primary" />
+									<Switch
+										id="primary-on"
+										defaultChecked={true}
+										color="primary"
+									/>
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">With Label</span>
@@ -105,7 +121,11 @@ export default createRoute((c) => {
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">On State</span>
-									<Switch id="secondary-on" defaultChecked={true} color="secondary" />
+									<Switch
+										id="secondary-on"
+										defaultChecked={true}
+										color="secondary"
+									/>
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">With Label</span>
@@ -142,7 +162,11 @@ export default createRoute((c) => {
 							<div class="space-y-4 p-6 rounded-lg border border-red-200 dark:border-red-800">
 								<div class="flex items-center justify-between">
 									<span class="text-sm">Off State</span>
-									<Switch id="danger-off" defaultChecked={false} color="danger" />
+									<Switch
+										id="danger-off"
+										defaultChecked={false}
+										color="danger"
+									/>
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">On State</span>
@@ -187,7 +211,11 @@ export default createRoute((c) => {
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">Primary</span>
-									<Switch id="compare-primary" defaultChecked={true} color="primary" />
+									<Switch
+										id="compare-primary"
+										defaultChecked={true}
+										color="primary"
+									/>
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">Secondary</span>
@@ -199,7 +227,11 @@ export default createRoute((c) => {
 								</div>
 								<div class="flex items-center justify-between">
 									<span class="text-sm">Danger</span>
-									<Switch id="compare-danger" defaultChecked={true} color="danger" />
+									<Switch
+										id="compare-danger"
+										defaultChecked={true}
+										color="danger"
+									/>
 								</div>
 							</div>
 						</section>

--- a/app/routes/settings/index.tsx
+++ b/app/routes/settings/index.tsx
@@ -1,3 +1,4 @@
+import DarkModeSwitch from "@/islands/dark-mode-switch";
 import LogoutButton from "@/islands/logout-button";
 import { createAuthenticatedRoute } from "@/utils/factory/hono";
 
@@ -16,6 +17,9 @@ export default createAuthenticatedRoute((c) => {
 							<p id="settings-email" class="mt-1">
 								{user.email}
 							</p>
+						</div>
+						<div class="pt-4 border-t">
+							<DarkModeSwitch />
 						</div>
 						<div class="pt-4 border-t">
 							<LogoutButton />


### PR DESCRIPTION
## Summary
- Add DarkModeSwitch island component that toggles `dark` class on `<html>` element
- Save user preference to localStorage for persistence across sessions
- Default to browser's `prefers-color-scheme` setting
- Integrate toggle into `/settings` page

## Test plan
- [x] Dark mode toggle switches theme globally
- [x] Preference persists after page reload (localStorage)
- [x] Respects browser preference on first visit
- [x] biome, tsc, unit tests pass

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)