### PR TITLE
Add reusable Button component with color variants

### DIFF
--- a/app/islands/button.tsx
+++ b/app/islands/button.tsx
@@ -1,0 +1,51 @@
+import type { JSX } from "hono/jsx/jsx-runtime";
+
+type ButtonProps = {
+	id: string;
+	type?: "button" | "submit" | "reset";
+	disabled?: boolean;
+	color?: "default" | "primary" | "secondary" | "danger";
+	fullWidth?: boolean;
+	onClick?: (e: MouseEvent) => void;
+	children: JSX.Element | string;
+};
+
+export default function Button({
+	id,
+	type = "button",
+	disabled = false,
+	color = "default",
+	fullWidth = false,
+	onClick,
+	children,
+}: ButtonProps): JSX.Element {
+	const baseClasses =
+		"px-4 py-2 rounded cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed transition-colors";
+
+	const colorClasses = {
+		default:
+			"bg-neutral-500 dark:bg-neutral-600 text-white hover:bg-neutral-600 dark:hover:bg-neutral-500",
+		primary:
+			"bg-emerald-500 dark:bg-emerald-600 text-white hover:bg-emerald-600 dark:hover:bg-emerald-500",
+		secondary:
+			"bg-fuchsia-500 dark:bg-fuchsia-600 text-white hover:bg-fuchsia-600 dark:hover:bg-fuchsia-500",
+		danger:
+			"bg-red-500 dark:bg-red-600 text-white hover:bg-red-600 dark:hover:bg-red-500",
+	};
+
+	const widthClass = fullWidth ? "w-full" : "";
+
+	const className = `${baseClasses} ${colorClasses[color]} ${widthClass}`;
+
+	return (
+		<button
+			type={type}
+			id={id}
+			disabled={disabled}
+			onClick={onClick}
+			class={className}
+		>
+			{children}
+		</button>
+	);
+}

--- a/app/islands/login-form.tsx
+++ b/app/islands/login-form.tsx
@@ -2,6 +2,7 @@ import { useState } from "hono/jsx";
 import type { JSX } from "hono/jsx/jsx-runtime";
 import { TextInput } from "@/components/text-input";
 import { apiClient } from "@/utils/api-client";
+import Button from "./button";
 
 export default function LoginForm(): JSX.Element {
 	const [email, setEmail] = useState("");
@@ -94,14 +95,15 @@ export default function LoginForm(): JSX.Element {
 				</p>
 			)}
 			{status === "error" && <p class="text-red-600 text-sm">{errorMessage}</p>}
-			<button
-				type="submit"
+			<Button
 				id="login-submit"
+				type="submit"
+				color="primary"
+				fullWidth
 				disabled={status === "loading"}
-				class="w-full px-4 py-2 bg-orange-400 text-white rounded cursor-pointer hover:bg-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
 			>
 				{status === "loading" ? "ログイン中..." : "ログイン"}
-			</button>
+			</Button>
 		</form>
 	);
 }

--- a/app/islands/logout-button.tsx
+++ b/app/islands/logout-button.tsx
@@ -1,6 +1,7 @@
 import { useState } from "hono/jsx";
 import type { JSX } from "hono/jsx/jsx-runtime";
 import { apiClient } from "@/utils/api-client";
+import Button from "./button";
 
 export default function LogoutButton(): JSX.Element {
 	const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
@@ -20,15 +21,13 @@ export default function LogoutButton(): JSX.Element {
 
 	return (
 		<div>
-			<button
-				type="button"
+			<Button
 				id="logout-button"
 				onClick={handleLogout}
 				disabled={status === "loading"}
-				class="px-4 py-2 bg-gray-500 text-white rounded cursor-pointer hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
 			>
 				{status === "loading" ? "ログアウト中..." : "ログアウト"}
-			</button>
+			</Button>
 			{status === "error" && (
 				<p class="mt-2 text-red-600 text-sm">
 					エラーが発生しました。再度お試しください

--- a/app/islands/signup-form.tsx
+++ b/app/islands/signup-form.tsx
@@ -2,6 +2,7 @@ import { useState } from "hono/jsx";
 import type { JSX } from "hono/jsx/jsx-runtime";
 import { TextInput } from "@/components/text-input";
 import { apiClient } from "@/utils/api-client";
+import Button from "./button";
 
 export default function SignupForm(): JSX.Element {
 	const [email, setEmail] = useState("");
@@ -59,14 +60,15 @@ export default function SignupForm(): JSX.Element {
 				disabled={status === "loading"}
 			/>
 			{status === "error" && <p class="text-red-600 text-sm">{errorMessage}</p>}
-			<button
-				type="submit"
+			<Button
 				id="signup-submit"
+				type="submit"
+				color="primary"
+				fullWidth
 				disabled={status === "loading"}
-				class="w-full px-4 py-2 bg-orange-400 text-white rounded cursor-pointer hover:bg-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
 			>
 				{status === "loading" ? "送信中..." : "招待メールを送信"}
-			</button>
+			</Button>
 		</form>
 	);
 }

--- a/app/islands/signup-verify-form.tsx
+++ b/app/islands/signup-verify-form.tsx
@@ -4,6 +4,7 @@ import { TextInput } from "@/components/text-input";
 import { PASSWORD_MIN_LENGTH } from "@/consts";
 import { apiClient } from "@/utils/api-client";
 import { validatePassword } from "@/utils/validation";
+import Button from "./button";
 
 type Props = {
 	email: string;
@@ -154,14 +155,15 @@ export default function SignupVerifyForm({ email, token }: Props) {
 
 			{status === "error" && <p class="text-red-600 text-sm">{errorMessage}</p>}
 
-			<button
-				type="submit"
+			<Button
 				id="signup-verify-submit"
+				type="submit"
+				color="primary"
+				fullWidth
 				disabled={!canSubmit}
-				class="w-full px-4 py-2 bg-orange-400 text-white rounded cursor-pointer hover:bg-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
 			>
 				{status === "loading" ? "登録中..." : "登録する"}
-			</button>
+			</Button>
 		</form>
 	);
 }

--- a/app/routes/components/button.tsx
+++ b/app/routes/components/button.tsx
@@ -1,0 +1,143 @@
+import { createRoute } from "honox/factory";
+import Button from "@/islands/button";
+import FloatingThemeToggle from "@/islands/floating-theme-toggle";
+
+export default createRoute((c) => {
+	return c.render(
+		<>
+			<title>Button Examples | User Auth Example</title>
+			<FloatingThemeToggle />
+			<div class="min-h-screen py-12 px-4">
+				<div class="max-w-2xl mx-auto space-y-12">
+					<div>
+						<h1 class="text-3xl font-bold text-center mb-2">
+							Button Component Examples
+						</h1>
+						<p class="text-center text-neutral-600 dark:text-neutral-400">
+							All color variants and states
+						</p>
+					</div>
+
+					<div class="space-y-8">
+						<section>
+							<h2 class="text-xl font-semibold mb-4">Default Color</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-neutral-200 dark:border-neutral-700">
+								<div class="flex items-center gap-4">
+									<Button id="default-1">Default Button</Button>
+									<Button id="default-2" disabled>
+										Disabled
+									</Button>
+								</div>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">
+								Primary Color (Emerald)
+							</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-emerald-200 dark:border-emerald-800">
+								<div class="flex items-center gap-4">
+									<Button id="primary-1" color="primary">
+										Primary Button
+									</Button>
+									<Button id="primary-2" color="primary" disabled>
+										Disabled
+									</Button>
+								</div>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">
+								Secondary Color (Fuchsia)
+							</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-fuchsia-200 dark:border-fuchsia-800">
+								<div class="flex items-center gap-4">
+									<Button id="secondary-1" color="secondary">
+										Secondary Button
+									</Button>
+									<Button id="secondary-2" color="secondary" disabled>
+										Disabled
+									</Button>
+								</div>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">Danger Color (Red)</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-red-200 dark:border-red-800">
+								<div class="flex items-center gap-4">
+									<Button id="danger-1" color="danger">
+										Danger Button
+									</Button>
+									<Button id="danger-2" color="danger" disabled>
+										Disabled
+									</Button>
+								</div>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">Button Types</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-neutral-200 dark:border-neutral-700">
+								<div class="flex items-center gap-4 flex-wrap">
+									<Button id="type-button" type="button" color="primary">
+										type="button"
+									</Button>
+									<Button id="type-submit" type="submit" color="secondary">
+										type="submit"
+									</Button>
+									<Button id="type-reset" type="reset" color="danger">
+										type="reset"
+									</Button>
+								</div>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">Full Width</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-neutral-200 dark:border-neutral-700">
+								<Button id="fullwidth-1" color="primary" fullWidth>
+									Full Width Primary
+								</Button>
+								<Button id="fullwidth-2" color="secondary" fullWidth>
+									Full Width Secondary
+								</Button>
+								<Button id="fullwidth-3" color="danger" fullWidth disabled>
+									Full Width Disabled
+								</Button>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">All Colors Comparison</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-neutral-200 dark:border-neutral-700">
+								<div class="flex items-center gap-4 flex-wrap">
+									<Button id="compare-default">Default</Button>
+									<Button id="compare-primary" color="primary">
+										Primary
+									</Button>
+									<Button id="compare-secondary" color="secondary">
+										Secondary
+									</Button>
+									<Button id="compare-danger" color="danger">
+										Danger
+									</Button>
+								</div>
+							</div>
+						</section>
+					</div>
+
+					<div class="text-center pt-8">
+						<a
+							href="/"
+							class="text-blue-600 dark:text-blue-400 hover:underline"
+						>
+							← Back to Home
+						</a>
+					</div>
+				</div>
+			</div>
+		</>,
+	);
+});


### PR DESCRIPTION
## Summary
- Create Button component in `islands/` with color variants (default, primary, secondary, danger)
- Support props: id (required), type, disabled, color, fullWidth, onClick, children
- Add dark mode support for all color variants
- Replace existing buttons in login, signup, signup-verify, and logout forms
- Add Button component example page at `/components/button`

Closes #42

## Test plan
- [x] Visit `/components/button` to verify all color variants and states
- [x] Test dark mode toggle on the button example page
- [x] Verify login form button works correctly
- [x] Verify signup form button works correctly
- [x] Verify logout button works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)