### PR TITLE
Add reusable Checkbox component with color variants

### DIFF
--- a/app/islands/checkbox.tsx
+++ b/app/islands/checkbox.tsx
@@ -1,0 +1,79 @@
+import { useState } from "hono/jsx";
+import type { JSX } from "hono/jsx/jsx-runtime";
+
+type CheckboxProps = {
+	id: string;
+	defaultChecked?: boolean;
+	disabled?: boolean;
+	color?: "default" | "primary" | "secondary" | "danger";
+	onChange?: (checked: boolean) => void;
+	children?: JSX.Element | string;
+};
+
+export default function Checkbox({
+	id,
+	defaultChecked = false,
+	disabled = false,
+	color = "default",
+	onChange,
+	children,
+}: CheckboxProps): JSX.Element {
+	const [checked, setChecked] = useState(defaultChecked);
+
+	const colorClasses = {
+		default: {
+			checkbox:
+				"text-neutral-500 focus:ring-neutral-500 dark:focus:ring-neutral-400",
+			label: "text-neutral-700 dark:text-neutral-300",
+		},
+		primary: {
+			checkbox:
+				"text-emerald-500 focus:ring-emerald-500 dark:focus:ring-emerald-400",
+			label: "text-neutral-700 dark:text-neutral-300",
+		},
+		secondary: {
+			checkbox:
+				"text-fuchsia-500 focus:ring-fuchsia-500 dark:focus:ring-fuchsia-400",
+			label: "text-neutral-700 dark:text-neutral-300",
+		},
+		danger: {
+			checkbox: "text-red-500 focus:ring-red-500 dark:focus:ring-red-400",
+			label: "text-neutral-700 dark:text-neutral-300",
+		},
+	};
+
+	const baseCheckboxClasses =
+		"h-4 w-4 border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-neutral-800";
+	const disabledClasses = disabled ? "opacity-50 cursor-not-allowed" : "";
+
+	const checkboxClassName = `${baseCheckboxClasses} ${colorClasses[color].checkbox} ${disabledClasses}`;
+	const labelClassName = `ml-2 block text-sm ${colorClasses[color].label} ${disabledClasses}`;
+
+	const handleChange = (e: Event) => {
+		if (disabled) return;
+		const target = e.target as HTMLInputElement;
+		const newChecked = target.checked;
+		setChecked(newChecked);
+		if (onChange) {
+			onChange(newChecked);
+		}
+	};
+
+	return (
+		<div class="flex items-center">
+			<input
+				type="checkbox"
+				id={id}
+				checked={checked}
+				onChange={handleChange}
+				disabled={disabled}
+				class={checkboxClassName}
+			/>
+			{children && (
+				<label for={id} class={labelClassName}>
+					{children}
+				</label>
+			)}
+		</div>
+	);
+}

--- a/app/islands/login-form.tsx
+++ b/app/islands/login-form.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "hono/jsx/jsx-runtime";
 import { TextInput } from "@/components/text-input";
 import { apiClient } from "@/utils/api-client";
 import Button from "./button";
+import Checkbox from "./checkbox";
 
 export default function LoginForm(): JSX.Element {
 	const [email, setEmail] = useState("");
@@ -74,21 +75,15 @@ export default function LoginForm(): JSX.Element {
 				disabled={status === "loading"}
 				color="secondary"
 			/>
-			<div class="flex items-center">
-				<input
-					type="checkbox"
-					id="login-remember-me"
-					checked={rememberMe}
-					onChange={(e) =>
-						setRememberMe((e.target as HTMLInputElement).checked)
-					}
-					class="h-4 w-4 text-orange-500 focus:ring-orange-500 border-gray-300 rounded"
-					disabled={status === "loading"}
-				/>
-				<label for="login-remember-me" class="ml-2 block text-sm text-gray-700">
-					ログイン状態を保持する
-				</label>
-			</div>
+			<Checkbox
+				id="login-remember-me"
+				defaultChecked={rememberMe}
+				onChange={setRememberMe}
+				disabled={status === "loading"}
+				color="primary"
+			>
+				ログイン状態を保持する
+			</Checkbox>
 			{!rememberMe && (
 				<p class="text-xs text-gray-500">
 					ブラウザの設定によっては、ブラウザを閉じてもログイン状態が維持される場合があります。共有のパソコンをお使いの場合など、確実にログアウトしたい場合は設定画面から手動でログアウトすることをおすすめします。

--- a/app/islands/signup-verify-form.tsx
+++ b/app/islands/signup-verify-form.tsx
@@ -5,6 +5,7 @@ import { PASSWORD_MIN_LENGTH } from "@/consts";
 import { apiClient } from "@/utils/api-client";
 import { validatePassword } from "@/utils/validation";
 import Button from "./button";
+import Checkbox from "./checkbox";
 
 type Props = {
 	email: string;
@@ -129,24 +130,15 @@ export default function SignupVerifyForm({ email, token }: Props) {
 				)}
 			</div>
 
-			<div class="flex items-center">
-				<input
-					type="checkbox"
-					id="signup-verify-remember-me"
-					checked={rememberMe}
-					onChange={(e) =>
-						setRememberMe((e.target as HTMLInputElement).checked)
-					}
-					class="h-4 w-4 text-orange-500 focus:ring-orange-500 border-gray-300 rounded"
-					disabled={status === "loading"}
-				/>
-				<label
-					for="signup-verify-remember-me"
-					class="ml-2 block text-sm text-gray-700"
-				>
-					ログイン状態を保持する
-				</label>
-			</div>
+			<Checkbox
+				id="signup-verify-remember-me"
+				defaultChecked={rememberMe}
+				onChange={setRememberMe}
+				disabled={status === "loading"}
+				color="primary"
+			>
+				ログイン状態を保持する
+			</Checkbox>
 			{!rememberMe && (
 				<p class="text-xs text-gray-500">
 					ブラウザの設定によっては、ブラウザを閉じてもログイン状態が維持される場合があります。共有のパソコンをお使いの場合など、確実にログアウトしたい場合は設定画面から手動でログアウトすることをおすすめします。

--- a/app/routes/components/checkbox.tsx
+++ b/app/routes/components/checkbox.tsx
@@ -1,0 +1,151 @@
+import { createRoute } from "honox/factory";
+import Checkbox from "@/islands/checkbox";
+import FloatingThemeToggle from "@/islands/floating-theme-toggle";
+
+export default createRoute((c) => {
+	return c.render(
+		<>
+			<title>Checkbox Examples | User Auth Example</title>
+			<FloatingThemeToggle />
+			<div class="min-h-screen py-12 px-4">
+				<div class="max-w-2xl mx-auto space-y-12">
+					<div>
+						<h1 class="text-3xl font-bold text-center mb-2">
+							Checkbox Component Examples
+						</h1>
+						<p class="text-center text-neutral-600 dark:text-neutral-400">
+							All color variants and states
+						</p>
+					</div>
+
+					<div class="space-y-8">
+						<section>
+							<h2 class="text-xl font-semibold mb-4">Default Color</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-neutral-200 dark:border-neutral-700">
+								<Checkbox id="default-1">Unchecked</Checkbox>
+								<Checkbox id="default-2" defaultChecked>
+									Checked
+								</Checkbox>
+								<Checkbox id="default-3" disabled>
+									Disabled Unchecked
+								</Checkbox>
+								<Checkbox id="default-4" defaultChecked disabled>
+									Disabled Checked
+								</Checkbox>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">
+								Primary Color (Emerald)
+							</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-emerald-200 dark:border-emerald-800">
+								<Checkbox id="primary-1" color="primary">
+									Unchecked
+								</Checkbox>
+								<Checkbox id="primary-2" color="primary" defaultChecked>
+									Checked
+								</Checkbox>
+								<Checkbox id="primary-3" color="primary" disabled>
+									Disabled Unchecked
+								</Checkbox>
+								<Checkbox
+									id="primary-4"
+									color="primary"
+									defaultChecked
+									disabled
+								>
+									Disabled Checked
+								</Checkbox>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">
+								Secondary Color (Fuchsia)
+							</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-fuchsia-200 dark:border-fuchsia-800">
+								<Checkbox id="secondary-1" color="secondary">
+									Unchecked
+								</Checkbox>
+								<Checkbox id="secondary-2" color="secondary" defaultChecked>
+									Checked
+								</Checkbox>
+								<Checkbox id="secondary-3" color="secondary" disabled>
+									Disabled Unchecked
+								</Checkbox>
+								<Checkbox
+									id="secondary-4"
+									color="secondary"
+									defaultChecked
+									disabled
+								>
+									Disabled Checked
+								</Checkbox>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">Danger Color (Red)</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-red-200 dark:border-red-800">
+								<Checkbox id="danger-1" color="danger">
+									Unchecked
+								</Checkbox>
+								<Checkbox id="danger-2" color="danger" defaultChecked>
+									Checked
+								</Checkbox>
+								<Checkbox id="danger-3" color="danger" disabled>
+									Disabled Unchecked
+								</Checkbox>
+								<Checkbox id="danger-4" color="danger" defaultChecked disabled>
+									Disabled Checked
+								</Checkbox>
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">Without Labels</h2>
+							<div class="flex items-center gap-6 p-6 rounded-lg border border-neutral-200 dark:border-neutral-700">
+								<Checkbox id="no-label-1" />
+								<Checkbox id="no-label-2" color="primary" defaultChecked />
+								<Checkbox id="no-label-3" color="secondary" />
+								<Checkbox id="no-label-4" color="danger" defaultChecked />
+							</div>
+						</section>
+
+						<section>
+							<h2 class="text-xl font-semibold mb-4">All Colors Comparison</h2>
+							<div class="space-y-4 p-6 rounded-lg border border-neutral-200 dark:border-neutral-700">
+								<Checkbox id="compare-default" defaultChecked>
+									Default
+								</Checkbox>
+								<Checkbox id="compare-primary" color="primary" defaultChecked>
+									Primary
+								</Checkbox>
+								<Checkbox
+									id="compare-secondary"
+									color="secondary"
+									defaultChecked
+								>
+									Secondary
+								</Checkbox>
+								<Checkbox id="compare-danger" color="danger" defaultChecked>
+									Danger
+								</Checkbox>
+							</div>
+						</section>
+					</div>
+
+					<div class="text-center pt-8">
+						<a
+							href="/"
+							class="text-blue-600 dark:text-blue-400 hover:underline"
+						>
+							← Back to Home
+						</a>
+					</div>
+				</div>
+			</div>
+		</>,
+	);
+});


### PR DESCRIPTION
## Summary
- Create Checkbox component in `islands/` with color variants (default, primary, secondary, danger)
- Support props: id (required), defaultChecked, disabled, color, onChange, children
- Add dark mode support for all color variants
- Replace existing checkboxes in login and signup-verify forms
- Add Checkbox component example page at `/components/checkbox`

Closes #44

## Test plan
- [x] Visit `/components/checkbox` to verify all color variants and states
- [x] Test dark mode toggle on the checkbox example page
- [x] Verify login form "remember me" checkbox works correctly
- [x] Verify signup-verify form "remember me" checkbox works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)