### PR TITLE
feat: add password change feature in settings page (#50)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,14 +94,29 @@ For all GitHub operations (creating issues, pull requests, searching code, etc.)
 ## Development workflows
 
 ### Plan A
-When the repository administrator ends a coding request with "プランAで対応して", follow this workflow:
+When the repository administrator ends a coding request with "Plan A", follow this workflow:
 
 1. Create an issue for the task
 2. Fetch, checkout `release/X.Y.Z`, pull, then create and checkout `feature/#n` from `release/X.Y.Z`
-3. Implement by referencing existing code patterns
-4. Create unit tests for pure functions
-5. Update E2E tests if new happy paths are added
-6. Run verification command: `docker exec user-auth-app bash -c "bun run biome && bun run tsc && bun run test:unit"`
-7. If verification succeeds, or after 3 attempts without resolution, request review from the repository administrator
-8. Address feedback from the repository administrator
-9. When the administrator requests a PR, commit, push, and create a pull request
+3. Update `package.json` version: use the release branch version (e.g., for `release/1.3.0` , update to `1.3.0` )
+4. Implement by referencing existing code patterns
+5. Create unit tests for pure functions
+6. Update E2E tests if new happy paths are added
+7. Run verification command: `docker exec user-auth-app bash -c "bun run biome && bun run tsc && bun run test:unit"`
+8. If verification succeeds, or after 3 attempts without resolution, request review from the repository administrator
+9. Address feedback from the repository administrator
+10. When the administrator requests a PR, commit, push, and create a pull request
+
+### Plan B
+When the repository administrator ends a coding request with "Plan B", follow this workflow:
+
+1. Create an issue for the task
+2. Fetch, checkout `main`, pull, then create and checkout `feature/#n` from `main`
+3. Update `package.json` version: check the latest tag and increment the minor version (e.g., if latest tag is `v1.3.0` , update to `1.4.0` )
+4. Implement by referencing existing code patterns
+5. Create unit tests for pure functions
+6. Update E2E tests if new happy paths are added
+7. Run verification command: `docker exec user-auth-app bash -c "bun run biome && bun run tsc && bun run test:unit"`
+8. If verification succeeds, or after 3 attempts without resolution, request review from the repository administrator
+9. Address feedback from the repository administrator
+10. When the administrator requests a PR, commit, push, and create a pull request

--- a/app/islands/password-change-form.tsx
+++ b/app/islands/password-change-form.tsx
@@ -1,0 +1,159 @@
+import { useState } from "hono/jsx";
+import type { JSX } from "hono/jsx/jsx-runtime";
+import { PASSWORD_MIN_LENGTH } from "@/consts";
+import Button from "@/islands/ui/button";
+import { TextInput } from "@/islands/ui/text-input";
+import { apiClient } from "@/utils/api-client";
+import { validatePassword } from "@/utils/validation";
+
+type Props = {
+	email: string;
+};
+
+function ValidationIcon({ isValid }: { isValid: boolean }): JSX.Element {
+	if (isValid) {
+		return <span class="text-green-600">&#10003;</span>;
+	}
+	return <span class="text-gray-400">&#10007;</span>;
+}
+
+export default function PasswordChangeForm({ email }: Props) {
+	const [currentPassword, setCurrentPassword] = useState("");
+	const [newPassword, setNewPassword] = useState("");
+	const [newPasswordConfirm, setNewPasswordConfirm] = useState("");
+	const [status, setStatus] = useState<
+		"idle" | "loading" | "success" | "error"
+	>("idle");
+	const [errorMessage, setErrorMessage] = useState("");
+
+	const validation = validatePassword(newPassword, email);
+	const passwordsMatch =
+		newPassword === newPasswordConfirm && newPassword.length > 0;
+	const canSubmit =
+		currentPassword.length > 0 &&
+		validation.isValid &&
+		passwordsMatch &&
+		status !== "loading";
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+		if (!canSubmit) return;
+
+		setStatus("loading");
+		setErrorMessage("");
+
+		const response = await apiClient.v1["password-change"].$post({
+			json: { currentPassword, newPassword },
+		});
+
+		if (response.ok) {
+			setStatus("success");
+			setCurrentPassword("");
+			setNewPassword("");
+			setNewPasswordConfirm("");
+			return;
+		}
+
+		setStatus("error");
+		if (response.status === 401) {
+			setErrorMessage("現在のパスワードが正しくありません");
+		} else if (response.status === 400) {
+			setErrorMessage("新しいパスワードが要件を満たしていません");
+		} else {
+			setErrorMessage(
+				"エラーが発生しました。しばらくしてから再度お試しください",
+			);
+		}
+	};
+
+	return (
+		<form id="password-change-form" onSubmit={handleSubmit} class="space-y-4">
+			<TextInput
+				id="password-change-current"
+				label="現在のパスワード"
+				type="password"
+				value={currentPassword}
+				onInput={(e) =>
+					setCurrentPassword((e.target as HTMLInputElement).value)
+				}
+				disabled={status === "loading"}
+			/>
+
+			<div>
+				<TextInput
+					id="password-change-new"
+					label="新しいパスワード"
+					type="password"
+					value={newPassword}
+					onInput={(e) => setNewPassword((e.target as HTMLInputElement).value)}
+					disabled={status === "loading"}
+				/>
+				<ul class="mt-2 text-sm space-y-1">
+					<li>
+						<ValidationIcon isValid={validation.isMinLength} />
+						<span class="ml-2">{PASSWORD_MIN_LENGTH}文字以上</span>
+					</li>
+					<li>
+						<ValidationIcon isValid={validation.hasThreeTypes} />
+						<span class="ml-2">
+							小文字・大文字・数字・記号から3種類以上
+							<span class="text-gray-500 ml-1">
+								(
+								{[
+									validation.hasLowercase && "小文字",
+									validation.hasUppercase && "大文字",
+									validation.hasNumber && "数字",
+									validation.hasSymbol && "記号",
+								]
+									.filter(Boolean)
+									.join(", ") || "なし"}
+								)
+							</span>
+						</span>
+					</li>
+					<li>
+						<ValidationIcon isValid={validation.isNotSimilarToEmail} />
+						<span class="ml-2">メールアドレスと似ていない</span>
+					</li>
+				</ul>
+			</div>
+
+			<div>
+				<TextInput
+					id="password-change-new-confirm"
+					label="新しいパスワード（確認用）"
+					type="password"
+					value={newPasswordConfirm}
+					onInput={(e) =>
+						setNewPasswordConfirm((e.target as HTMLInputElement).value)
+					}
+					disabled={status === "loading"}
+				/>
+				{newPasswordConfirm.length > 0 && (
+					<p
+						class={`mt-1 text-sm ${passwordsMatch ? "text-green-600" : "text-red-600"}`}
+					>
+						{passwordsMatch
+							? "パスワードが一致しています"
+							: "パスワードが一致しません"}
+					</p>
+				)}
+			</div>
+
+			{status === "error" && <p class="text-red-600 text-sm">{errorMessage}</p>}
+			{status === "success" && (
+				<p class="text-green-600 text-sm">パスワードを変更しました</p>
+			)}
+
+			<Button
+				id="password-change-submit"
+				type="submit"
+				color="primary"
+				fullWidth
+				disabled={!canSubmit}
+			>
+				{status === "loading" ? "変更中..." : "変更する"}
+			</Button>
+		</form>
+	);
+}

--- a/app/routes/api/v1/password-change/index.ts
+++ b/app/routes/api/v1/password-change/index.ts
@@ -1,0 +1,69 @@
+import { sValidator } from "@hono/standard-validator";
+import { eq } from "drizzle-orm";
+import { z } from "zod/v4";
+import { BAD_REQUEST, OK, UNAUTHORIZED } from "@/consts";
+import { getDBClient } from "@/db/client";
+import { usersTable } from "@/db/schemas";
+import { loginRequired } from "@/middlewares/auth";
+import { injectExternalErrors } from "@/middlewares/external-errors";
+import { generateSalt, hashPassword } from "@/utils/crypto/server";
+import { createHonoApp } from "@/utils/factory/hono";
+import { validatePassword } from "@/utils/validation";
+
+const jsonValidator = sValidator(
+	"json",
+	z.object({
+		currentPassword: z.string().min(1),
+		newPassword: z.string().min(1),
+	}),
+	(result, c) => {
+		if (!result.success) {
+			return c.text(BAD_REQUEST, 400);
+		}
+	},
+);
+
+export const route = createHonoApp().post(
+	"/",
+	loginRequired,
+	jsonValidator,
+	injectExternalErrors,
+	async (c) => {
+		const { currentPassword, newPassword } = c.req.valid("json");
+		const user = c.get("user");
+
+		const db = getDBClient(c.env.DB);
+
+		const dbUser = await db
+			.select()
+			.from(usersTable)
+			.where(eq(usersTable.id, user.id))
+			.get();
+
+		if (!dbUser || !dbUser.salt || !dbUser.passwordHash) {
+			return c.text(UNAUTHORIZED, 401);
+		}
+
+		const currentPasswordHash = hashPassword(currentPassword, dbUser.salt);
+
+		if (currentPasswordHash !== dbUser.passwordHash) {
+			return c.text(UNAUTHORIZED, 401);
+		}
+
+		if (!validatePassword(newPassword, user.email).isValid) {
+			return c.text(BAD_REQUEST, 400);
+		}
+
+		const salt = generateSalt();
+		const passwordHash = hashPassword(newPassword, salt);
+
+		await db
+			.update(usersTable)
+			.set({ salt, passwordHash })
+			.where(eq(usersTable.id, user.id));
+
+		return c.text(OK, 200);
+	},
+);
+
+export default route;

--- a/app/routes/settings/index.tsx
+++ b/app/routes/settings/index.tsx
@@ -1,5 +1,6 @@
 import DarkModeSwitch from "@/islands/dark-mode-switch";
 import LogoutButton from "@/islands/logout-button";
+import PasswordChangeForm from "@/islands/password-change-form";
 import { createAuthenticatedRoute } from "@/utils/factory/hono";
 
 export default createAuthenticatedRoute((c) => {
@@ -17,6 +18,10 @@ export default createAuthenticatedRoute((c) => {
 							<p id="settings-email" class="mt-1">
 								{user.email}
 							</p>
+						</div>
+						<div class="pt-4 border-t">
+							<span class="block text-sm font-medium mb-2">パスワード変更</span>
+							<PasswordChangeForm email={user.email} />
 						</div>
 						<div class="pt-4 border-t">
 							<DarkModeSwitch />

--- a/app/utils/api-client/routes.ts
+++ b/app/utils/api-client/routes.ts
@@ -1,5 +1,6 @@
 import apiV1Login from "@/routes/api/v1/login";
 import apiV1Logout from "@/routes/api/v1/logout";
+import apiV1PasswordChange from "@/routes/api/v1/password-change";
 import apiV1PasswordReset from "@/routes/api/v1/password-reset";
 import apiV1PasswordResetVerify from "@/routes/api/v1/password-reset/verify";
 import apiV1Signup from "@/routes/api/v1/signup";
@@ -9,6 +10,7 @@ import { createHonoApp } from "@/utils/factory/hono";
 const apiRoutes = createHonoApp()
 	.route("/api/v1/login", apiV1Login)
 	.route("/api/v1/logout", apiV1Logout)
+	.route("/api/v1/password-change", apiV1PasswordChange)
 	.route("/api/v1/password-reset", apiV1PasswordReset)
 	.route("/api/v1/password-reset/verify", apiV1PasswordResetVerify)
 	.route("/api/v1/signup", apiV1Signup)

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,6 +6,7 @@
     - [`POST /api/v1/signup/verify`](#POST-apiv1signupverify) : Verify signup session and create user account.
     - [`POST /api/v1/login`](#POST-apiv1login) : Authenticate user and issue JWT.
     - [`POST /api/v1/logout`](#POST-apiv1logout) : Clear authentication cookies and invalidate session.
+    - [`POST /api/v1/password-change`](#POST-apiv1password-change) : Change password for authenticated user.
     - [`POST /api/v1/password-reset`](#POST-apiv1password-reset) : Send password reset email.
     - [`POST /api/v1/password-reset/verify`](#POST-apiv1password-resetverify) : Verify reset token and update password.
 
@@ -86,6 +87,30 @@ type ResponseText = "OK" | "Unauthorized"
 2. Deletes the current login session from `login_sessions` table
 3. Clears access token and refresh token cookies
 4. Returns `200 OK`
+
+### `POST /api/v1/password-change`
+
+```ts
+type RequestJSON = {
+    currentPassword: string;
+    newPassword: string;
+}
+
+type ResponseText = "OK" | "Bad Request" | "Unauthorized"
+```
+
+#### Password Requirements
+- At least 8 characters
+- Contains 3 or more types from: lowercase letters, uppercase letters, numbers, symbols
+- Not similar to the email address
+
+#### Flow
+1. Returns `401 Unauthorized` if not authenticated
+2. Returns `400 Bad Request` if the request body is not valid JSON
+3. Returns `401 Unauthorized` if the current password is incorrect
+4. Returns `400 Bad Request` if the new password does not meet requirements
+5. Updates the user's password in the `users` table
+6. Returns `200 OK`
 
 ### `POST /api/v1/password-reset`
 

--- a/docs/PAGE.md
+++ b/docs/PAGE.md
@@ -96,15 +96,35 @@ User settings page for managing account.
 
 #### Components
 - User's email address display
+- Password change form:
+    - Current password input field
+    - New password input field with validation indicators:
+        - At least 8 characters
+        - Contains 3+ types from: lowercase, uppercase, numbers, symbols
+        - Not similar to email address
+    - New password confirmation input field
+        - Must match new password field
+    - Submit button ("変更する")
 - Logout button
 
 #### Behavior
 1. `createAuthenticatedRoute` middleware validates authentication
 2. If validation fails: Redirects to `/login?redirect=%2Fsettings`
-3. If validation succeeds: Displays user's email address and logout button
-4. User clicks logout button
-5. Calls `POST /api/v1/logout`
-6. On success (200): Redirects to `/`
+3. If validation succeeds: Displays user's email address, password change form, and logout button
+
+Password change:
+1. User enters current password
+2. User enters new password with real-time validation feedback
+3. User confirms new password
+4. User clicks submit button
+5. Calls `POST /api/v1/password-change` with current and new password
+6. On success (200): Displays success message and clears form
+7. On error: Displays appropriate error message
+
+Logout:
+1. User clicks logout button
+2. Calls `POST /api/v1/logout`
+3. On success (200): Redirects to `/`
 
 ### `/password-reset`
 

--- a/e2e/signup-login.spec.ts
+++ b/e2e/signup-login.spec.ts
@@ -176,6 +176,47 @@ test.describe("Signup and Login Happy Path", () => {
 		await expect(page.locator("h1")).toHaveText("ホーム");
 		await expect(page.locator("#logged-in-email")).toContainText(testEmail);
 
+		// 20. Navigate to settings page for password change test
+		await page.click('[data-testid="settings-link"]');
+		await expect(page.locator("h1")).toHaveText("設定");
+
+		// 21. Change password via settings form
+		const changedPassword = "ChangedPass789!";
+		await page.waitForSelector("#password-change-form", { state: "attached" });
+		await page.locator("#password-change-current").fill(newPassword);
+		await page.locator("#password-change-new").fill(changedPassword);
+		await page.locator("#password-change-new-confirm").fill(changedPassword);
+
+		const passwordChangeSubmit = page.locator("#password-change-submit");
+		await expect(passwordChangeSubmit).toBeEnabled();
+		await passwordChangeSubmit.click();
+
+		// Wait for success message
+		await expect(page.locator("text=パスワードを変更しました")).toBeVisible({
+			timeout: 10000,
+		});
+
+		// 22. Logout after password change
+		await page.click("#logout-button");
+		await page.waitForURL("/", { timeout: 10000 });
+		await expect(page.locator("h1")).toHaveText("ホーム");
+
+		// 23. Login with changed password
+		await page.click('[data-testid="login-link"]');
+		await expect(page.locator("h1")).toHaveText("ログイン");
+
+		await page.waitForSelector("#login-form", { state: "attached" });
+		await page.locator("#login-email").fill(testEmail);
+		await page.locator("#login-password").fill(changedPassword);
+		await page.locator("#login-submit").click();
+
+		// Wait for navigation to complete after login
+		await page.waitForURL("/", { timeout: 10000 });
+
+		// Verify successful login with changed password
+		await expect(page.locator("h1")).toHaveText("ホーム");
+		await expect(page.locator("#logged-in-email")).toContainText(testEmail);
+
 		// Cleanup: delete the password reset email
 		if (resetEmail.id) {
 			await mailosaur.messages.del(resetEmail.id);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "user-auth-example",
 	"type": "module",
-	"version": "1.0.0",
+	"version": "1.4.0",
 	"private": true,
 	"scripts": {
 		"db:generate": "drizzle-kit generate --name create_tables",


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/password-change` endpoint for authenticated users to change their password
- Add password change form to settings page with real-time validation
- Update API.md and PAGE.md documentation
- Add E2E test for password change flow
- Update package.json version to 1.4.0

## Test plan
- [x] biome check passes
- [x] tsc check passes
- [x] Unit tests pass
- [x] E2E tests pass

Closes #50